### PR TITLE
feat: add openrazer-daemon recipe

### DIFF
--- a/.github/workflows/containers-fedora-kinoite-41.yml
+++ b/.github/workflows/containers-fedora-kinoite-41.yml
@@ -600,6 +600,25 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+  
+      - name: "Push container: openrazer-daemon"
+        uses: redhat-actions/push-to-registry@v2
+        id: push-openrazer-daemon
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.DESTINATION }}
+          registry: ${{ env.REGISTRY }}
+          tags: ${{ env.RELEASE }}.openrazer-daemon
+
+      - name: "Sign container: openrazer-daemon"
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+            cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-openh264.outputs.digest }}
+        env:
+            COSIGN_EXPERIMENTAL: false
+            COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
       - name: "Push container: ripgrep"
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/sysexts-fedora-kinoite-41.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41.yml
@@ -168,6 +168,14 @@ jobs:
           just build ${IMAGE}
           mv "${SYSEXT}.raw" "../artifacts/"
 
+      - name: "Build sysext: openrazer-daemon"
+        env:
+          SYSEXT: openrazer-daemon
+        run: |
+          cd "${SYSEXT}"
+          just build ${IMAGE}
+          mv "${SYSEXT}.raw" "../artifacts/"
+          
       - name: "Build sysext: ripgrep"
         env:
           SYSEXT: ripgrep

--- a/openrazer-daemon/Containerfile
+++ b/openrazer-daemon/Containerfile
@@ -1,6 +1,8 @@
 FROM baseimage
 
-RUN dnf install -y \
+RUN dnf install -y dnf5-plugins \
+    dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo \
+    dnf install -y \
     openrazer-daemon \
     && \
     dnf clean all

--- a/openrazer-daemon/Containerfile
+++ b/openrazer-daemon/Containerfile
@@ -1,0 +1,6 @@
+FROM baseimage
+
+RUN dnf install -y \
+    openrazer-daemon \
+    && \
+    dnf clean all

--- a/openrazer-daemon/justfile
+++ b/openrazer-daemon/justfile
@@ -1,6 +1,6 @@
 name := "openrazer-daemon"
 packages := "openrazer-daemon"
-external_repos := "https://download.opensuse.org/repositories/hardware:/razer/Fedora_41/hardware:razer.repo"
+external_repos := "https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo"
 base_images := "quay.io/fedora-ostree-desktops/kinoite:41"
 arch := "noarch"
 import '../sysext.just'

--- a/openrazer-daemon/justfile
+++ b/openrazer-daemon/justfile
@@ -1,0 +1,8 @@
+name := "openrazer-daemon"
+packages := "openrazer-daemon"
+external_repos := "https://download.opensuse.org/repositories/hardware:/razer/Fedora_41/hardware:razer.repo"
+base_images := "quay.io/fedora-ostree-desktops/kinoite:41"
+arch := "noarch"
+import '../sysext.just'
+
+all: default


### PR DESCRIPTION
openrazer-daemon pull a lot of kernel package and header files unfortunately.

```bison-0:3.8.2-9.fc41.x86_64                                                     100% |   1.1 MiB/s |   1.0 MiB |  00m01s
 flex-0:2.6.4-18.fc41.x86_64                                                     100% |   3.2 MiB/s | 298.2 KiB |  00m00s
 elfutils-libelf-devel-0:0.192-5.fc41.x86_64                                     100% |  11.6 KiB/s |  47.3 KiB |  00m04s
 dkms-0:3.1.1-1.fc41.noarch                                                      100% |  15.8 KiB/s |  82.5 KiB |  00m05s
 gcc-0:14.2.1-3.fc41.x86_64                                                      100% |   5.8 MiB/s |  36.9 MiB |  00m06s
 kernel-devel-matched-0:6.11.5-300.fc41.x86_64                                   100% |  58.5 KiB/s | 183.1 KiB |  00m03s
 kernel-headers-0:6.11.3-300.fc41.x86_64                                         100% |   4.7 MiB/s |   1.6 MiB |  00m00s
 libxcrypt-devel-0:4.4.36-7.fc41.x86_64                                          100% |  97.5 KiB/s |  28.9 KiB |  00m00s
 libzstd-devel-0:1.5.6-2.fc41.x86_64                                             100% | 631.9 KiB/s |  51.8 KiB |  00m00s
 m4-0:1.4.19-10.fc41.x86_64                                                      100% |   2.4 MiB/s | 305.4 KiB |  00m00s
 make-1:4.4.1-8.fc41.x86_64                                                      100% |   3.3 MiB/s | 586.1 KiB |  00m00s
 glibc-devel-0:2.40-9.fc41.x86_64                                                100% |  76.4 KiB/s | 632.4 KiB |  00m08s
 openrazer-kernel-modules-dkms-0:3.9.0-1.1.noarch                                100% |  97.9 KiB/s |  63.4 KiB |  00m01s
 openssl-devel-1:3.2.2-9.fc41.x86_64                                             100% |   5.5 MiB/s |   2.8 MiB |  00m01s
 python3-daemonize-0:2.5.0-21.fc41.noarch                                        100% | 223.8 KiB/s |  18.3 KiB |  00m00s
 python3-setproctitle-0:1.3.3-2.fc41.x86_64                                      100% | 316.0 KiB/s |  24.3 KiB |  00m00s
 xautomation-0:1.09-11.fc41.x86_64                                               100% | 678.3 KiB/s |  61.7 KiB |  00m00s
 zlib-ng-compat-devel-0:2.1.7-3.fc41.x86_64                                      100% | 482.2 KiB/s |  38.1 KiB |  00m00s
 openrazer-daemon-0:3.9.0-1.1.noarch                                             100% |  34.4 KiB/s | 187.2 KiB |  00m05s
 kernel-devel-0:6.11.5-300.fc41.x86_64                                           100% |   1.5 MiB/s |  20.9 MiB |  00m14s```

