### PR TITLE
libvirtd/libvirtd-desktop: Add libvirtdbus docs

### DIFF
--- a/libvirtd-desktop/README.md
+++ b/libvirtd-desktop/README.md
@@ -7,13 +7,33 @@
   ```
   $ sudo systemd-sysusers /usr/lib/sysusers.d/libvirt-qemu.conf
   ```
+- Create the `libvirtdbus` user and group:
+  ```
+  $ sudo bash -c 'getent group libvirtdbus >/dev/null || groupadd -r libvirtdbus'
+  $ sudo bash -c 'getent passwd libvirtdbus >/dev/null || \
+      useradd -r -g libvirtdbus -d / -s /sbin/nologin \
+      -c "Libvirt D-Bus bridge" libvirtdbus'
+  ```
+- Create the `libvirt` group to allow password-less polkit access to libvirt deamons:
+  ```
+  $ sudo bash -c 'getent group libvirt >/dev/null || groupadd -r libvirt'
+  ```
+- Optional: Add your UID to the libvirt group
+  ```
+  $ sudo usermod -G -a libvirt $YOUR-UID-HERE
+  ```
+- Copy the default libvirt dbus config and fix the selinux label
+  ```
+  $ sudo cp -a /usr/share/dbus-1/system.d/org.libvirt.conf /etc/dbus-1/system.d/
+  $ sudo restorecon -Fv /etc/dbus-1/system.d/org.libvirt.conf
+  ```
 - Copy the some default config:
   ```
   $ sudo cp -a /usr/etc/mdevctl.d /etc/
   ```
 - Optional: Copy the default libvirtd config (note that it won't be updated automatically):
   ```
-  $ sudo cp -a /usr/etc/libvirtd /etc/
+  $ sudo cp -a /usr/etc/libvirt /etc/
   ```
 - Optional: Setup auth via polkit (example):
   ```
@@ -28,4 +48,8 @@
 - Enable libvirtd:
   ```
   $ sudo systemctl enable --now libvirtd
+  ```
+- Enable virtqemud:
+  ```
+  $ sudo systemctl enable --now virtqemud
   ```

--- a/libvirtd/README.md
+++ b/libvirtd/README.md
@@ -7,13 +7,33 @@
   ```
   $ sudo systemd-sysusers /usr/lib/sysusers.d/libvirt-qemu.conf
   ```
+- Create the `libvirtdbus` user and group:
+  ```
+  $ sudo bash -c 'getent group libvirtdbus >/dev/null || groupadd -r libvirtdbus'
+  $ sudo bash -c 'getent passwd libvirtdbus >/dev/null || \
+      useradd -r -g libvirtdbus -d / -s /sbin/nologin \
+      -c "Libvirt D-Bus bridge" libvirtdbus'
+  ```
+- Create the `libvirt` group to allow password-less polkit access to libvirt deamons:
+  ```
+  $ sudo bash -c 'getent group libvirt >/dev/null || groupadd -r libvirt'
+  ```
+- Optional: Add your UID to the libvirt group
+  ```
+  $ sudo usermod -G -a libvirt $YOUR-UID-HERE
+  ```
+- Copy the default libvirt dbus config and fix the selinux label
+  ```
+  $ sudo cp -a /usr/share/dbus-1/system.d/org.libvirt.conf /etc/dbus-1/system.d/
+  $ sudo restorecon -Fv /etc/dbus-1/system.d/org.libvirt.conf
+  ```
 - Copy the some default config:
   ```
   $ sudo cp -a /usr/etc/mdevctl.d /etc/
   ```
 - Optional: Copy the default libvirtd config (note that it won't be updated automatically):
   ```
-  $ sudo cp -a /usr/etc/libvirtd /etc/
+  $ sudo cp -a /usr/etc/libvirt /etc/
   ```
 - Optional: Setup auth via polkit (example):
   ```
@@ -28,4 +48,8 @@
 - Enable libvirtd:
   ```
   $ sudo systemctl enable --now libvirtd
+  ```
+- Enable virtqemud:
+  ```
+  $ sudo systemctl enable --now virtqemud
   ```


### PR DESCRIPTION
The additions to the libvirt READMEs are the outcome of my investigation on how to get Cockpit Virtual Machines tab to allow me to manage VMs. I tried to follow the same code style as the existing documentation.  Feel free to modify as needed.

Fixes:
- typo on config copy: `sudo cp -a /usr/etc/libvirtd /etc/` -> `sudo cp -a /usr/etc/libvirt /etc/`

Additions:
- Added users and groups required to get `libvirt-dbus.service` working, copied from the `libvirtdbus.spec` file.
- Added `libvirt` group from the `libvirt.spec` file.
- Added `/etc/dbus-1/system.d/org.libvirt.conf` file creation from <https://www.libvirt.org/dbus.html>
  - TODO: verify this does not grant unintended access
- Enabled the `virtqemud` service.

I'm leaving this as a draft PR for now until I get a chance to double-check the added steps.



