### PR TITLE
sysext.just: List each extracted packages & Move /run out

### DIFF
--- a/sysext.just
+++ b/sysext.just
@@ -198,12 +198,11 @@ install-rpms:
 
     cd rootfs
 
-    echo "📦 Extracting packages"
+    echo "📦 Extracting packages:"
     for rpm in ../rpms/*.rpm; do
-        echo -n "$(basename ${rpm}) "
+        echo "$(basename ${rpm})"
         rpm2cpio "${rpm}" | ${SUDO} cpio -idmv &> /dev/null
     done
-    echo ""
 
 # Install files from the current directory. Uses:
 # - files: List of folders or files to copy to `rootfs`. Use either `usr` or

--- a/sysext.just
+++ b/sysext.just
@@ -258,7 +258,7 @@ move-etc:
     fi
 
 # Move all folders outside of /usr & /opt out of the sysext's rootfs.
-# Note: This step is still in progress. Currently only moves /var.
+# Note: This step is still in progress. Currently only moves /var and /run.
 rm-ignored:
     #!/bin/bash
     set -euo pipefail
@@ -278,7 +278,7 @@ rm-ignored:
 
     cd rootfs
 
-    for dir in "var" "etc"; do
+    for dir in "var" "run"; do
         if [[ -d ./"${dir}" ]] then
             echo "➡️ Moving ${dir} out of rootfs"
             ${SUDO} mv ./"${dir}" ../rootfs.ignored


### PR DESCRIPTION
sysext.just: List each extracted packages on its own line

This makes the log more readable in CI.

---

sysext.just: Move /run out of the sysext (ignored)

/run is ignored so let's move it out of the sysext.