### PR TITLE
sysext.just: Support setting up services to uphold

### DIFF
--- a/cri-o-1.29/justfile
+++ b/cri-o-1.29/justfile
@@ -6,6 +6,9 @@ cri-tools1.29
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/cri-o-1.30/justfile
+++ b/cri-o-1.30/justfile
@@ -6,6 +6,9 @@ cri-tools1.30
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/cri-o-1.31/justfile
+++ b/cri-o-1.31/justfile
@@ -6,6 +6,9 @@ cri-tools1.31
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/cri-o-1.32/justfile
+++ b/cri-o-1.32/justfile
@@ -6,6 +6,9 @@ cri-tools1.32
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/docker-ce/README.md
+++ b/docker-ce/README.md
@@ -9,8 +9,7 @@ Docker Engine from [community repos](https://docs.docker.com/engine/install/fedo
   ```
   $ sudo groupadd --system docker
   ```
-- Enable and start the daemon:
+- Restart the socket:
   ```
-  $ sudo systemctl enable --now docker
+  $ sudo systemctl enable --now docker.socket
   ```
-- For an unknown reason yet, you will have to start it manually on each boot.

--- a/docker-ce/justfile
+++ b/docker-ce/justfile
@@ -6,6 +6,9 @@ containerd.io
 docker-buildx-plugin
 docker-compose-plugin
 "
+upholds := "
+docker.socket
+"
 external_repos := "https://download.docker.com/linux/fedora/docker-ce.repo"
 base_images := "
 quay.io/fedora-ostree-desktops/silverblue:41

--- a/kubernetes-1.29/justfile
+++ b/kubernetes-1.29/justfile
@@ -9,6 +9,9 @@ kubernetes1.29-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-1.30/justfile
+++ b/kubernetes-1.30/justfile
@@ -9,6 +9,9 @@ kubernetes1.30-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-1.31/justfile
+++ b/kubernetes-1.31/justfile
@@ -9,6 +9,9 @@ kubernetes1.31-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-1.32/justfile
+++ b/kubernetes-1.32/justfile
@@ -9,6 +9,9 @@ kubernetes1.32-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -10,6 +10,10 @@ kubernetes1.29-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -10,6 +10,10 @@ kubernetes1.30-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -10,6 +10,10 @@ kubernetes1.31-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-cri-o-1.32/justfile
+++ b/kubernetes-cri-o-1.32/justfile
@@ -10,6 +10,10 @@ kubernetes1.32-systemd
 exclude_packages := "
 cri-tools
 "
+upholds := "
+crio.service
+kubelet.service
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/libvirtd-desktop/README.md
+++ b/libvirtd-desktop/README.md
@@ -30,8 +30,8 @@ See the [Virtual Machine Manager Flatpak](https://flathub.org/apps/org.virt_mana
       }
   });
   ```
-- Enable libvirtd (via virtqemud & virtnetworkd):
+- Enable and restart libvirtd (via virtqemud, virtnetworkd & virtstoraged):
   ```
-  $ sudo systemctl enable --now virtqemud.socket virtnetworkd.socket virtstoraged.socket
+  $ sudo systemctl enable virtqemud.socket virtnetworkd.socket virtstoraged.socket
+  $ sudo systemctl restart virtqemud.socket virtnetworkd.socket virtstoraged.socket
   ```
-- For an unknown reason yet, you will have to start them manually on each boot.

--- a/libvirtd-desktop/justfile
+++ b/libvirtd-desktop/justfile
@@ -20,6 +20,11 @@ qemu-img
 swtpm
 virt-install
 "
+upholds := "
+virtqemud.socket
+virtnetworkd.socket
+virtstoraged.socket
+"
 base_images := "
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/silverblue:42

--- a/libvirtd/README.md
+++ b/libvirtd/README.md
@@ -30,8 +30,8 @@ See the [Virtual Machine Manager Flatpak](https://flathub.org/apps/org.virt_mana
       }
   });
   ```
-- Enable libvirtd (via virtqemud & virtnetworkd):
+- Enable and restart libvirtd (via virtqemud, virtnetworkd & virtstoraged):
   ```
-  $ sudo systemctl enable --now virtqemud.socket virtnetworkd.socket virtstoraged.socket
+  $ sudo systemctl enable virtqemud.socket virtnetworkd.socket virtstoraged.socket
+  $ sudo systemctl restart virtqemud.socket virtnetworkd.socket virtstoraged.socket
   ```
-- For an unknown reason yet, you will have to start them manually on each boot.

--- a/libvirtd/justfile
+++ b/libvirtd/justfile
@@ -27,6 +27,11 @@ qemu-kvm
 swtpm
 virt-install
 "
+upholds := "
+virtqemud.socket
+virtnetworkd.socket
+virtstoraged.socket
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable
 "

--- a/moby-engine/README.md
+++ b/moby-engine/README.md
@@ -1,0 +1,13 @@
+# moby-engine
+
+## How to use
+
+- Install the sysext
+- Create the `docker` group:
+  ```
+  $ sudo groupadd --system docker
+  ```
+- Restart the socket:
+  ```
+  $ sudo systemctl enable --now docker.socket
+  ```

--- a/moby-engine/justfile
+++ b/moby-engine/justfile
@@ -1,5 +1,8 @@
 name := "moby-engine"
 packages := "moby-engine"
+upholds := "
+docker.socket
+"
 base_images := "
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/silverblue:42

--- a/sysext.just
+++ b/sysext.just
@@ -40,6 +40,9 @@ dnf_arch := ""
 # Do not install any additional files by default
 files := ""
 
+# Do not setup any upholds for units by default
+upholds := ""
+
 # zstd compression is still experimental in EROFS
 # compression := "zstd"
 compression := "lz4"
@@ -261,6 +264,33 @@ setup-rootfs arch=arch:
     mkdir rootfs
     cd rootfs
 
+    # Only ask systemd to reload its configuration if we have services to
+    # uphold / start on boot
+    reload_manager="false"
+
+    # Filter the variable into an array
+    upholds=()
+    mapfile -t upholds_raw <<< "{{upholds}}"
+    for uphold in "${upholds_raw[@]}"; do
+        if [[ -z "${uphold}" ]]; then
+            continue
+        fi
+        upholds+=("${uphold}")
+    done
+    # Setup upholds if there are any
+    if [[ "${#upholds[@]}" -ne 0 ]]; then
+        # Set now, but will be used later in the extension config file
+        reload_manager="true"
+        echo "➡️ Setting up upholds for: ${upholds[@]}"
+        ${SUDO} install -d -m 0755 -o 0 -g 0 usr/lib/systemd/system/multi-user.target.d
+        {
+        echo "[Unit]"
+        for uphold in "${upholds[@]}"; do
+            echo "Upholds=${uphold}"
+        done
+        } | ${SUDO} tee "usr/lib/systemd/system/multi-user.target.d/10-{{name}}-sysext.conf" > /dev/null
+    fi
+
     echo "➡️ Setting up extension config file"
     ${SUDO} install -d -m0755 usr/lib/extension-release.d
     {
@@ -268,6 +298,9 @@ setup-rootfs arch=arch:
     # Post process architecture to match systemd architecture list
     arch="$(echo {{arch}} | sed 's/_/-/g')"
     echo "ARCHITECTURE=\"${arch}\""
+    if [[ "${reload_manager}"  == "true" ]]; then
+        echo "EXTENSION_RELOAD_MANAGER=1"
+    fi
     } | ${SUDO} tee "usr/lib/extension-release.d/extension-release.{{name}}" > /dev/null
 
 # Install (extract) RPM packages download in download-rpms recipe. Uses:


### PR DESCRIPTION
sysext.just: Support setting up services to uphold

System services that are included in sysexts are not started on boot,
even if enabled.

This works around this issue by using the `Upholds` directive [1] to
make sure that those units are started.

Note that this bypasses the enabled/disabled state, but it is still
possible to mask the unit, or remove the sysext entirely.

This will also set the `EXTENSION_RELOAD_MANAGER=1` option for the
sysexts which tell systemd-sysext to ask systemd to reload its
configuration when the sysexts are loaded [2].

[1]: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Upholds=
[2]: https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html

See: https://github.com/flatcar/sysext-bakery/blob/87f4af7e579846c6d9c16d7db70f3cfa1b57a805/create_kubernetes_sysext.sh#L89-L90

---

Use upholds to start services on boot

---

docker-ce: Use upholds to start the socket

---

libvirtd*: Update READMEs

---

moby-engine: Use upholds & add README