### PR TITLE
firefox: Add initial sysext

### DIFF
--- a/.github/workflows/sysexts-fedora-kinoite-41.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41.yml
@@ -127,6 +127,14 @@ jobs:
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: firefox"
+        env:
+          SYSEXT: firefox
+        run: |
+          cd "${SYSEXT}"
+          just build ${IMAGE}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: fuse2"
         env:
           SYSEXT: fuse2

--- a/.github/workflows/sysexts-fedora-silverblue-41.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41.yml
@@ -127,6 +127,14 @@ jobs:
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: firefox"
+        env:
+          SYSEXT: firefox
+        run: |
+          cd "${SYSEXT}"
+          just build ${IMAGE}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: fuse2"
         env:
           SYSEXT: fuse2

--- a/firefox/README.md
+++ b/firefox/README.md
@@ -1,0 +1,3 @@
+# firefox
+
+Enables use on dowstream images such as Bazzite and Bluefin which remove Firefox.

--- a/firefox/justfile
+++ b/firefox/justfile
@@ -1,0 +1,13 @@
+name := "firefox"
+packages := "
+firefox
+firefox-langpacks
+"
+base_images := "
+quay.io/fedora-ostree-desktops/silverblue:41
+quay.io/fedora-ostree-desktops/kinoite:41
+"
+
+import '../sysext.just'
+
+all: default

--- a/update_workflows.sh
+++ b/update_workflows.sh
@@ -93,17 +93,21 @@ main() {
         "${tmpl}/containers_header"
     echo ""
     for s in "${sysexts[@]}"; do
-        sed "s|%%SYSEXT%%|${s}|g" "${tmpl}/containers_build"
-        echo ""
+        if [[ -f "${s}/Containerfile" ]]; then
+            sed "s|%%SYSEXT%%|${s}|g" "${tmpl}/containers_build"
+            echo ""
+        fi
     done
     cat "${tmpl}/containers_logincosign"
     echo ""
     for s in "${sysexts[@]}"; do
-        sed \
-            -e "s|%%SYSEXT%%|${s}|g" \
-            -e "s|%%SYSEXT_NODOT%%|${s//\./_}|g" \
-            "${tmpl}/containers_pushsign"
-        echo ""
+        if [[ -f "${s}/Containerfile" ]]; then
+            sed \
+                -e "s|%%SYSEXT%%|${s}|g" \
+                -e "s|%%SYSEXT_NODOT%%|${s//\./_}|g" \
+                "${tmpl}/containers_pushsign"
+            echo ""
+        fi
     done
     } > ".github/workflows/containers-${shortname}-${release}.yml"
 }


### PR DESCRIPTION
While Firefox exists in silverblue/kinoite today, this enables use on downstream images (eg Bazzite and Bluefin) where Firefox is removed from the system image.