### PR TITLE
kubernetes-cri-o-*: Add initial sysexts & Add READMEs

### DIFF
--- a/.github/workflows/containers-fedora-coreos-stable.yml
+++ b/.github/workflows/containers-fedora-coreos-stable.yml
@@ -6,6 +6,7 @@ env:
   NAME: 'Fedora CoreOS (stable)'
   REGISTRY: 'quay.io/travier'
   DESTINATION: 'fedora-coreos-sysexts'
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -37,8 +38,30 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: "Checking if we need to build container: 1password-cli"
+        id: check-1password-cli
+        env:
+          SYSEXT: 1password-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: 1password-cli"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-1password-cli.outputs.BUILD == 'true')
         with:
           context: '1password-cli'
           image: ${{ env.DESTINATION }}
@@ -50,8 +73,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: btop"
+        id: check-btop
+        env:
+          SYSEXT: btop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: btop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-btop.outputs.BUILD == 'true')
         with:
           context: 'btop'
           image: ${{ env.DESTINATION }}
@@ -63,8 +103,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: cockpit"
+        id: check-cockpit
+        env:
+          SYSEXT: cockpit
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: cockpit"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-cockpit.outputs.BUILD == 'true')
         with:
           context: 'cockpit'
           image: ${{ env.DESTINATION }}
@@ -76,8 +133,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: compsize"
+        id: check-compsize
+        env:
+          SYSEXT: compsize
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: compsize"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-compsize.outputs.BUILD == 'true')
         with:
           context: 'compsize'
           image: ${{ env.DESTINATION }}
@@ -89,8 +163,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: cri-o-1.29"
+        id: check-cri-o-1_29
+        env:
+          SYSEXT: cri-o-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: cri-o-1.29"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-cri-o-1_29.outputs.BUILD == 'true')
         with:
           context: 'cri-o-1.29'
           image: ${{ env.DESTINATION }}
@@ -102,8 +193,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: cri-o-1.30"
+        id: check-cri-o-1_30
+        env:
+          SYSEXT: cri-o-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: cri-o-1.30"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-cri-o-1_30.outputs.BUILD == 'true')
         with:
           context: 'cri-o-1.30'
           image: ${{ env.DESTINATION }}
@@ -115,8 +223,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: cri-o-1.31"
+        id: check-cri-o-1_31
+        env:
+          SYSEXT: cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: cri-o-1.31"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-cri-o-1_31.outputs.BUILD == 'true')
         with:
           context: 'cri-o-1.31'
           image: ${{ env.DESTINATION }}
@@ -128,8 +253,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: distrobox"
+        id: check-distrobox
+        env:
+          SYSEXT: distrobox
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: distrobox"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-distrobox.outputs.BUILD == 'true')
         with:
           context: 'distrobox'
           image: ${{ env.DESTINATION }}
@@ -141,8 +283,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: erofs-utils"
+        id: check-erofs-utils
+        env:
+          SYSEXT: erofs-utils
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: erofs-utils"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-erofs-utils.outputs.BUILD == 'true')
         with:
           context: 'erofs-utils'
           image: ${{ env.DESTINATION }}
@@ -154,8 +313,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: gdb"
+        id: check-gdb
+        env:
+          SYSEXT: gdb
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: gdb"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-gdb.outputs.BUILD == 'true')
         with:
           context: 'gdb'
           image: ${{ env.DESTINATION }}
@@ -167,8 +343,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: git-tools"
+        id: check-git-tools
+        env:
+          SYSEXT: git-tools
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: git-tools"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-git-tools.outputs.BUILD == 'true')
         with:
           context: 'git-tools'
           image: ${{ env.DESTINATION }}
@@ -180,8 +373,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: htop"
+        id: check-htop
+        env:
+          SYSEXT: htop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: htop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-htop.outputs.BUILD == 'true')
         with:
           context: 'htop'
           image: ${{ env.DESTINATION }}
@@ -193,8 +403,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: incus"
+        id: check-incus
+        env:
+          SYSEXT: incus
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: incus"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-incus.outputs.BUILD == 'true')
         with:
           context: 'incus'
           image: ${{ env.DESTINATION }}
@@ -206,8 +433,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: iwd"
+        id: check-iwd
+        env:
+          SYSEXT: iwd
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: iwd"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-iwd.outputs.BUILD == 'true')
         with:
           context: 'iwd'
           image: ${{ env.DESTINATION }}
@@ -219,8 +463,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: just"
+        id: check-just
+        env:
+          SYSEXT: just
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: just"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-just.outputs.BUILD == 'true')
         with:
           context: 'just'
           image: ${{ env.DESTINATION }}
@@ -232,8 +493,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: kubernetes-1.29"
+        id: check-kubernetes-1_29
+        env:
+          SYSEXT: kubernetes-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: kubernetes-1.29"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-1_29.outputs.BUILD == 'true')
         with:
           context: 'kubernetes-1.29'
           image: ${{ env.DESTINATION }}
@@ -245,8 +523,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: kubernetes-1.30"
+        id: check-kubernetes-1_30
+        env:
+          SYSEXT: kubernetes-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: kubernetes-1.30"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-1_30.outputs.BUILD == 'true')
         with:
           context: 'kubernetes-1.30'
           image: ${{ env.DESTINATION }}
@@ -258,8 +553,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: kubernetes-1.31"
+        id: check-kubernetes-1_31
+        env:
+          SYSEXT: kubernetes-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: kubernetes-1.31"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-1_31.outputs.BUILD == 'true')
         with:
           context: 'kubernetes-1.31'
           image: ${{ env.DESTINATION }}
@@ -271,8 +583,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: libvirtd"
+        id: check-libvirtd
+        env:
+          SYSEXT: libvirtd
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: libvirtd"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-libvirtd.outputs.BUILD == 'true')
         with:
           context: 'libvirtd'
           image: ${{ env.DESTINATION }}
@@ -284,8 +613,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: monitoring"
+        id: check-monitoring
+        env:
+          SYSEXT: monitoring
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: monitoring"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-monitoring.outputs.BUILD == 'true')
         with:
           context: 'monitoring'
           image: ${{ env.DESTINATION }}
@@ -297,8 +643,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: neovim"
+        id: check-neovim
+        env:
+          SYSEXT: neovim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: neovim"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-neovim.outputs.BUILD == 'true')
         with:
           context: 'neovim'
           image: ${{ env.DESTINATION }}
@@ -310,8 +673,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: python"
+        id: check-python
+        env:
+          SYSEXT: python
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: python"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-python.outputs.BUILD == 'true')
         with:
           context: 'python'
           image: ${{ env.DESTINATION }}
@@ -323,8 +703,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: ripgrep"
+        id: check-ripgrep
+        env:
+          SYSEXT: ripgrep
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: ripgrep"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-ripgrep.outputs.BUILD == 'true')
         with:
           context: 'ripgrep'
           image: ${{ env.DESTINATION }}
@@ -336,8 +733,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: semanage"
+        id: check-semanage
+        env:
+          SYSEXT: semanage
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: semanage"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-semanage.outputs.BUILD == 'true')
         with:
           context: 'semanage'
           image: ${{ env.DESTINATION }}
@@ -349,8 +763,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: strace"
+        id: check-strace
+        env:
+          SYSEXT: strace
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: strace"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-strace.outputs.BUILD == 'true')
         with:
           context: 'strace'
           image: ${{ env.DESTINATION }}
@@ -362,8 +793,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: tree"
+        id: check-tree
+        env:
+          SYSEXT: tree
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: tree"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-tree.outputs.BUILD == 'true')
         with:
           context: 'tree'
           image: ${{ env.DESTINATION }}
@@ -375,8 +823,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vim"
+        id: check-vim
+        env:
+          SYSEXT: vim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vim"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vim.outputs.BUILD == 'true')
         with:
           context: 'vim'
           image: ${{ env.DESTINATION }}
@@ -388,8 +853,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: zsh"
+        id: check-zsh
+        env:
+          SYSEXT: zsh
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: zsh"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-zsh.outputs.BUILD == 'true')
         with:
           context: 'zsh'
           image: ${{ env.DESTINATION }}

--- a/.github/workflows/containers-fedora-coreos-stable.yml
+++ b/.github/workflows/containers-fedora-coreos-stable.yml
@@ -583,6 +583,96 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: kubernetes-cri-o-1.29"
+        id: check-kubernetes-cri-o-1_29
+        env:
+          SYSEXT: kubernetes-cri-o-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
+      - name: "Build container: kubernetes-cri-o-1.29"
+        uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-cri-o-1_29.outputs.BUILD == 'true')
+        with:
+          context: 'kubernetes-cri-o-1.29'
+          image: ${{ env.DESTINATION }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.29
+          containerfiles: 'kubernetes-cri-o-1.29/Containerfile'
+          layers: false
+          oci: true
+          extra-args:
+            --from
+            ${{ env.IMAGE }}:${{ env.RELEASE }}
+
+      - name: "Checking if we need to build container: kubernetes-cri-o-1.30"
+        id: check-kubernetes-cri-o-1_30
+        env:
+          SYSEXT: kubernetes-cri-o-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
+      - name: "Build container: kubernetes-cri-o-1.30"
+        uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-cri-o-1_30.outputs.BUILD == 'true')
+        with:
+          context: 'kubernetes-cri-o-1.30'
+          image: ${{ env.DESTINATION }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.30
+          containerfiles: 'kubernetes-cri-o-1.30/Containerfile'
+          layers: false
+          oci: true
+          extra-args:
+            --from
+            ${{ env.IMAGE }}:${{ env.RELEASE }}
+
+      - name: "Checking if we need to build container: kubernetes-cri-o-1.31"
+        id: check-kubernetes-cri-o-1_31
+        env:
+          SYSEXT: kubernetes-cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
+      - name: "Build container: kubernetes-cri-o-1.31"
+        uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-cri-o-1_31.outputs.BUILD == 'true')
+        with:
+          context: 'kubernetes-cri-o-1.31'
+          image: ${{ env.DESTINATION }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.31
+          containerfiles: 'kubernetes-cri-o-1.31/Containerfile'
+          layers: false
+          oci: true
+          extra-args:
+            --from
+            ${{ env.IMAGE }}:${{ env.RELEASE }}
+
       - name: "Checking if we need to build container: libvirtd"
         id: check-libvirtd
         env:
@@ -1232,6 +1322,63 @@ jobs:
         if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-kubernetes-1_31.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+      - name: "Push container: kubernetes-cri-o-1.29"
+        uses: redhat-actions/push-to-registry@v2
+        id: push-kubernetes-cri-o-1_29
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.DESTINATION }}
+          registry: ${{ env.REGISTRY }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.29
+
+      - name: "Sign container: kubernetes-cri-o-1.29"
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-kubernetes-cri-o-1_29.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+      - name: "Push container: kubernetes-cri-o-1.30"
+        uses: redhat-actions/push-to-registry@v2
+        id: push-kubernetes-cri-o-1_30
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.DESTINATION }}
+          registry: ${{ env.REGISTRY }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.30
+
+      - name: "Sign container: kubernetes-cri-o-1.30"
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-kubernetes-cri-o-1_30.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+      - name: "Push container: kubernetes-cri-o-1.31"
+        uses: redhat-actions/push-to-registry@v2
+        id: push-kubernetes-cri-o-1_31
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.DESTINATION }}
+          registry: ${{ env.REGISTRY }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.31
+
+      - name: "Sign container: kubernetes-cri-o-1.31"
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-kubernetes-cri-o-1_31.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/containers-fedora-kinoite-41.yml
+++ b/.github/workflows/containers-fedora-kinoite-41.yml
@@ -6,6 +6,7 @@ env:
   NAME: 'Fedora Kinoite (41)'
   REGISTRY: 'quay.io/travier'
   DESTINATION: 'fedora-kinoite-sysexts'
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -37,8 +38,30 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: "Checking if we need to build container: 1password-cli"
+        id: check-1password-cli
+        env:
+          SYSEXT: 1password-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: 1password-cli"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-1password-cli.outputs.BUILD == 'true')
         with:
           context: '1password-cli'
           image: ${{ env.DESTINATION }}
@@ -50,8 +73,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: 1password-gui"
+        id: check-1password-gui
+        env:
+          SYSEXT: 1password-gui
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: 1password-gui"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-1password-gui.outputs.BUILD == 'true')
         with:
           context: '1password-gui'
           image: ${{ env.DESTINATION }}
@@ -63,8 +103,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: btop"
+        id: check-btop
+        env:
+          SYSEXT: btop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: btop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-btop.outputs.BUILD == 'true')
         with:
           context: 'btop'
           image: ${{ env.DESTINATION }}
@@ -76,8 +133,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: chromium"
+        id: check-chromium
+        env:
+          SYSEXT: chromium
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: chromium"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-chromium.outputs.BUILD == 'true')
         with:
           context: 'chromium'
           image: ${{ env.DESTINATION }}
@@ -89,8 +163,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: compsize"
+        id: check-compsize
+        env:
+          SYSEXT: compsize
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: compsize"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-compsize.outputs.BUILD == 'true')
         with:
           context: 'compsize'
           image: ${{ env.DESTINATION }}
@@ -102,8 +193,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: distrobox"
+        id: check-distrobox
+        env:
+          SYSEXT: distrobox
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: distrobox"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-distrobox.outputs.BUILD == 'true')
         with:
           context: 'distrobox'
           image: ${{ env.DESTINATION }}
@@ -115,8 +223,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: docker-ce"
+        id: check-docker-ce
+        env:
+          SYSEXT: docker-ce
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: docker-ce"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-docker-ce.outputs.BUILD == 'true')
         with:
           context: 'docker-ce'
           image: ${{ env.DESTINATION }}
@@ -128,8 +253,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: emacs"
+        id: check-emacs
+        env:
+          SYSEXT: emacs
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: emacs"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-emacs.outputs.BUILD == 'true')
         with:
           context: 'emacs'
           image: ${{ env.DESTINATION }}
@@ -141,8 +283,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: erofs-utils"
+        id: check-erofs-utils
+        env:
+          SYSEXT: erofs-utils
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: erofs-utils"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-erofs-utils.outputs.BUILD == 'true')
         with:
           context: 'erofs-utils'
           image: ${{ env.DESTINATION }}
@@ -154,8 +313,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: fuse2"
+        id: check-fuse2
+        env:
+          SYSEXT: fuse2
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: fuse2"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-fuse2.outputs.BUILD == 'true')
         with:
           context: 'fuse2'
           image: ${{ env.DESTINATION }}
@@ -167,8 +343,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: gdb"
+        id: check-gdb
+        env:
+          SYSEXT: gdb
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: gdb"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-gdb.outputs.BUILD == 'true')
         with:
           context: 'gdb'
           image: ${{ env.DESTINATION }}
@@ -180,8 +373,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: git-tools"
+        id: check-git-tools
+        env:
+          SYSEXT: git-tools
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: git-tools"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-git-tools.outputs.BUILD == 'true')
         with:
           context: 'git-tools'
           image: ${{ env.DESTINATION }}
@@ -193,8 +403,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: google-chrome"
+        id: check-google-chrome
+        env:
+          SYSEXT: google-chrome
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: google-chrome"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-google-chrome.outputs.BUILD == 'true')
         with:
           context: 'google-chrome'
           image: ${{ env.DESTINATION }}
@@ -206,8 +433,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: htop"
+        id: check-htop
+        env:
+          SYSEXT: htop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: htop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-htop.outputs.BUILD == 'true')
         with:
           context: 'htop'
           image: ${{ env.DESTINATION }}
@@ -219,8 +463,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: incus"
+        id: check-incus
+        env:
+          SYSEXT: incus
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: incus"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-incus.outputs.BUILD == 'true')
         with:
           context: 'incus'
           image: ${{ env.DESTINATION }}
@@ -232,8 +493,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: iwd"
+        id: check-iwd
+        env:
+          SYSEXT: iwd
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: iwd"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-iwd.outputs.BUILD == 'true')
         with:
           context: 'iwd'
           image: ${{ env.DESTINATION }}
@@ -245,8 +523,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: just"
+        id: check-just
+        env:
+          SYSEXT: just
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: just"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-just.outputs.BUILD == 'true')
         with:
           context: 'just'
           image: ${{ env.DESTINATION }}
@@ -258,8 +553,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: keepassxc"
+        id: check-keepassxc
+        env:
+          SYSEXT: keepassxc
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: keepassxc"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-keepassxc.outputs.BUILD == 'true')
         with:
           context: 'keepassxc'
           image: ${{ env.DESTINATION }}
@@ -271,8 +583,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: krb5-workstation"
+        id: check-krb5-workstation
+        env:
+          SYSEXT: krb5-workstation
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: krb5-workstation"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-krb5-workstation.outputs.BUILD == 'true')
         with:
           context: 'krb5-workstation'
           image: ${{ env.DESTINATION }}
@@ -284,8 +613,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: libvirtd-desktop"
+        id: check-libvirtd-desktop
+        env:
+          SYSEXT: libvirtd-desktop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: libvirtd-desktop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-libvirtd-desktop.outputs.BUILD == 'true')
         with:
           context: 'libvirtd-desktop'
           image: ${{ env.DESTINATION }}
@@ -297,8 +643,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: microsoft-edge"
+        id: check-microsoft-edge
+        env:
+          SYSEXT: microsoft-edge
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: microsoft-edge"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-microsoft-edge.outputs.BUILD == 'true')
         with:
           context: 'microsoft-edge'
           image: ${{ env.DESTINATION }}
@@ -310,8 +673,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: moby-engine"
+        id: check-moby-engine
+        env:
+          SYSEXT: moby-engine
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: moby-engine"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-moby-engine.outputs.BUILD == 'true')
         with:
           context: 'moby-engine'
           image: ${{ env.DESTINATION }}
@@ -323,8 +703,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: monitoring"
+        id: check-monitoring
+        env:
+          SYSEXT: monitoring
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: monitoring"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-monitoring.outputs.BUILD == 'true')
         with:
           context: 'monitoring'
           image: ${{ env.DESTINATION }}
@@ -336,8 +733,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: mullvad-vpn"
+        id: check-mullvad-vpn
+        env:
+          SYSEXT: mullvad-vpn
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: mullvad-vpn"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-mullvad-vpn.outputs.BUILD == 'true')
         with:
           context: 'mullvad-vpn'
           image: ${{ env.DESTINATION }}
@@ -349,8 +763,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: neovim"
+        id: check-neovim
+        env:
+          SYSEXT: neovim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: neovim"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-neovim.outputs.BUILD == 'true')
         with:
           context: 'neovim'
           image: ${{ env.DESTINATION }}
@@ -362,8 +793,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: openh264"
+        id: check-openh264
+        env:
+          SYSEXT: openh264
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: openh264"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-openh264.outputs.BUILD == 'true')
         with:
           context: 'openh264'
           image: ${{ env.DESTINATION }}
@@ -375,8 +823,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: ripgrep"
+        id: check-ripgrep
+        env:
+          SYSEXT: ripgrep
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: ripgrep"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-ripgrep.outputs.BUILD == 'true')
         with:
           context: 'ripgrep'
           image: ${{ env.DESTINATION }}
@@ -388,8 +853,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: steam-devices"
+        id: check-steam-devices
+        env:
+          SYSEXT: steam-devices
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: steam-devices"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-steam-devices.outputs.BUILD == 'true')
         with:
           context: 'steam-devices'
           image: ${{ env.DESTINATION }}
@@ -401,8 +883,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: steam"
+        id: check-steam
+        env:
+          SYSEXT: steam
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: steam"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-steam.outputs.BUILD == 'true')
         with:
           context: 'steam'
           image: ${{ env.DESTINATION }}
@@ -414,8 +913,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: strace"
+        id: check-strace
+        env:
+          SYSEXT: strace
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: strace"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-strace.outputs.BUILD == 'true')
         with:
           context: 'strace'
           image: ${{ env.DESTINATION }}
@@ -427,8 +943,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: tree"
+        id: check-tree
+        env:
+          SYSEXT: tree
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: tree"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-tree.outputs.BUILD == 'true')
         with:
           context: 'tree'
           image: ${{ env.DESTINATION }}
@@ -440,8 +973,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vim"
+        id: check-vim
+        env:
+          SYSEXT: vim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vim"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vim.outputs.BUILD == 'true')
         with:
           context: 'vim'
           image: ${{ env.DESTINATION }}
@@ -453,8 +1003,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vscode"
+        id: check-vscode
+        env:
+          SYSEXT: vscode
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vscode"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vscode.outputs.BUILD == 'true')
         with:
           context: 'vscode'
           image: ${{ env.DESTINATION }}
@@ -466,8 +1033,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vscodium"
+        id: check-vscodium
+        env:
+          SYSEXT: vscodium
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vscodium"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vscodium.outputs.BUILD == 'true')
         with:
           context: 'vscodium'
           image: ${{ env.DESTINATION }}
@@ -479,8 +1063,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: wireguard-tools"
+        id: check-wireguard-tools
+        env:
+          SYSEXT: wireguard-tools
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: wireguard-tools"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-wireguard-tools.outputs.BUILD == 'true')
         with:
           context: 'wireguard-tools'
           image: ${{ env.DESTINATION }}
@@ -492,8 +1093,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: zoxide"
+        id: check-zoxide
+        env:
+          SYSEXT: zoxide
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: zoxide"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-zoxide.outputs.BUILD == 'true')
         with:
           context: 'zoxide'
           image: ${{ env.DESTINATION }}
@@ -505,8 +1123,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: zsh"
+        id: check-zsh
+        env:
+          SYSEXT: zsh
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: zsh"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-zsh.outputs.BUILD == 'true')
         with:
           context: 'zsh'
           image: ${{ env.DESTINATION }}

--- a/.github/workflows/containers-fedora-silverblue-41.yml
+++ b/.github/workflows/containers-fedora-silverblue-41.yml
@@ -6,6 +6,7 @@ env:
   NAME: 'Fedora Silverblue (41)'
   REGISTRY: 'quay.io/travier'
   DESTINATION: 'fedora-silverblue-sysexts'
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -37,8 +38,30 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: "Checking if we need to build container: 1password-cli"
+        id: check-1password-cli
+        env:
+          SYSEXT: 1password-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: 1password-cli"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-1password-cli.outputs.BUILD == 'true')
         with:
           context: '1password-cli'
           image: ${{ env.DESTINATION }}
@@ -50,8 +73,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: 1password-gui"
+        id: check-1password-gui
+        env:
+          SYSEXT: 1password-gui
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: 1password-gui"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-1password-gui.outputs.BUILD == 'true')
         with:
           context: '1password-gui'
           image: ${{ env.DESTINATION }}
@@ -63,8 +103,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: btop"
+        id: check-btop
+        env:
+          SYSEXT: btop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: btop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-btop.outputs.BUILD == 'true')
         with:
           context: 'btop'
           image: ${{ env.DESTINATION }}
@@ -76,8 +133,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: chromium"
+        id: check-chromium
+        env:
+          SYSEXT: chromium
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: chromium"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-chromium.outputs.BUILD == 'true')
         with:
           context: 'chromium'
           image: ${{ env.DESTINATION }}
@@ -89,8 +163,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: compsize"
+        id: check-compsize
+        env:
+          SYSEXT: compsize
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: compsize"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-compsize.outputs.BUILD == 'true')
         with:
           context: 'compsize'
           image: ${{ env.DESTINATION }}
@@ -102,8 +193,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: distrobox"
+        id: check-distrobox
+        env:
+          SYSEXT: distrobox
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: distrobox"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-distrobox.outputs.BUILD == 'true')
         with:
           context: 'distrobox'
           image: ${{ env.DESTINATION }}
@@ -115,8 +223,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: docker-ce"
+        id: check-docker-ce
+        env:
+          SYSEXT: docker-ce
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: docker-ce"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-docker-ce.outputs.BUILD == 'true')
         with:
           context: 'docker-ce'
           image: ${{ env.DESTINATION }}
@@ -128,8 +253,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: emacs"
+        id: check-emacs
+        env:
+          SYSEXT: emacs
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: emacs"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-emacs.outputs.BUILD == 'true')
         with:
           context: 'emacs'
           image: ${{ env.DESTINATION }}
@@ -141,8 +283,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: erofs-utils"
+        id: check-erofs-utils
+        env:
+          SYSEXT: erofs-utils
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: erofs-utils"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-erofs-utils.outputs.BUILD == 'true')
         with:
           context: 'erofs-utils'
           image: ${{ env.DESTINATION }}
@@ -154,8 +313,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: fuse2"
+        id: check-fuse2
+        env:
+          SYSEXT: fuse2
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: fuse2"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-fuse2.outputs.BUILD == 'true')
         with:
           context: 'fuse2'
           image: ${{ env.DESTINATION }}
@@ -167,8 +343,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: gdb"
+        id: check-gdb
+        env:
+          SYSEXT: gdb
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: gdb"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-gdb.outputs.BUILD == 'true')
         with:
           context: 'gdb'
           image: ${{ env.DESTINATION }}
@@ -180,8 +373,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: git-tools"
+        id: check-git-tools
+        env:
+          SYSEXT: git-tools
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: git-tools"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-git-tools.outputs.BUILD == 'true')
         with:
           context: 'git-tools'
           image: ${{ env.DESTINATION }}
@@ -193,8 +403,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: google-chrome"
+        id: check-google-chrome
+        env:
+          SYSEXT: google-chrome
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: google-chrome"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-google-chrome.outputs.BUILD == 'true')
         with:
           context: 'google-chrome'
           image: ${{ env.DESTINATION }}
@@ -206,8 +433,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: htop"
+        id: check-htop
+        env:
+          SYSEXT: htop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: htop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-htop.outputs.BUILD == 'true')
         with:
           context: 'htop'
           image: ${{ env.DESTINATION }}
@@ -219,8 +463,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: incus"
+        id: check-incus
+        env:
+          SYSEXT: incus
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: incus"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-incus.outputs.BUILD == 'true')
         with:
           context: 'incus'
           image: ${{ env.DESTINATION }}
@@ -232,8 +493,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: iwd"
+        id: check-iwd
+        env:
+          SYSEXT: iwd
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: iwd"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-iwd.outputs.BUILD == 'true')
         with:
           context: 'iwd'
           image: ${{ env.DESTINATION }}
@@ -245,8 +523,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: just"
+        id: check-just
+        env:
+          SYSEXT: just
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: just"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-just.outputs.BUILD == 'true')
         with:
           context: 'just'
           image: ${{ env.DESTINATION }}
@@ -258,8 +553,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: keepassxc"
+        id: check-keepassxc
+        env:
+          SYSEXT: keepassxc
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: keepassxc"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-keepassxc.outputs.BUILD == 'true')
         with:
           context: 'keepassxc'
           image: ${{ env.DESTINATION }}
@@ -271,8 +583,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: krb5-workstation"
+        id: check-krb5-workstation
+        env:
+          SYSEXT: krb5-workstation
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: krb5-workstation"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-krb5-workstation.outputs.BUILD == 'true')
         with:
           context: 'krb5-workstation'
           image: ${{ env.DESTINATION }}
@@ -284,8 +613,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: libvirtd-desktop"
+        id: check-libvirtd-desktop
+        env:
+          SYSEXT: libvirtd-desktop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: libvirtd-desktop"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-libvirtd-desktop.outputs.BUILD == 'true')
         with:
           context: 'libvirtd-desktop'
           image: ${{ env.DESTINATION }}
@@ -297,8 +643,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: microsoft-edge"
+        id: check-microsoft-edge
+        env:
+          SYSEXT: microsoft-edge
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: microsoft-edge"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-microsoft-edge.outputs.BUILD == 'true')
         with:
           context: 'microsoft-edge'
           image: ${{ env.DESTINATION }}
@@ -310,8 +673,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: moby-engine"
+        id: check-moby-engine
+        env:
+          SYSEXT: moby-engine
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: moby-engine"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-moby-engine.outputs.BUILD == 'true')
         with:
           context: 'moby-engine'
           image: ${{ env.DESTINATION }}
@@ -323,8 +703,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: monitoring"
+        id: check-monitoring
+        env:
+          SYSEXT: monitoring
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: monitoring"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-monitoring.outputs.BUILD == 'true')
         with:
           context: 'monitoring'
           image: ${{ env.DESTINATION }}
@@ -336,8 +733,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: mullvad-vpn"
+        id: check-mullvad-vpn
+        env:
+          SYSEXT: mullvad-vpn
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: mullvad-vpn"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-mullvad-vpn.outputs.BUILD == 'true')
         with:
           context: 'mullvad-vpn'
           image: ${{ env.DESTINATION }}
@@ -349,8 +763,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: neovim"
+        id: check-neovim
+        env:
+          SYSEXT: neovim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: neovim"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-neovim.outputs.BUILD == 'true')
         with:
           context: 'neovim'
           image: ${{ env.DESTINATION }}
@@ -362,8 +793,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: openh264"
+        id: check-openh264
+        env:
+          SYSEXT: openh264
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: openh264"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-openh264.outputs.BUILD == 'true')
         with:
           context: 'openh264'
           image: ${{ env.DESTINATION }}
@@ -375,8 +823,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: ripgrep"
+        id: check-ripgrep
+        env:
+          SYSEXT: ripgrep
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: ripgrep"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-ripgrep.outputs.BUILD == 'true')
         with:
           context: 'ripgrep'
           image: ${{ env.DESTINATION }}
@@ -388,8 +853,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: steam-devices"
+        id: check-steam-devices
+        env:
+          SYSEXT: steam-devices
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: steam-devices"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-steam-devices.outputs.BUILD == 'true')
         with:
           context: 'steam-devices'
           image: ${{ env.DESTINATION }}
@@ -401,8 +883,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: steam"
+        id: check-steam
+        env:
+          SYSEXT: steam
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: steam"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-steam.outputs.BUILD == 'true')
         with:
           context: 'steam'
           image: ${{ env.DESTINATION }}
@@ -414,8 +913,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: strace"
+        id: check-strace
+        env:
+          SYSEXT: strace
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: strace"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-strace.outputs.BUILD == 'true')
         with:
           context: 'strace'
           image: ${{ env.DESTINATION }}
@@ -427,8 +943,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: tree"
+        id: check-tree
+        env:
+          SYSEXT: tree
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: tree"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-tree.outputs.BUILD == 'true')
         with:
           context: 'tree'
           image: ${{ env.DESTINATION }}
@@ -440,8 +973,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vim"
+        id: check-vim
+        env:
+          SYSEXT: vim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vim"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vim.outputs.BUILD == 'true')
         with:
           context: 'vim'
           image: ${{ env.DESTINATION }}
@@ -453,8 +1003,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vscode"
+        id: check-vscode
+        env:
+          SYSEXT: vscode
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vscode"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vscode.outputs.BUILD == 'true')
         with:
           context: 'vscode'
           image: ${{ env.DESTINATION }}
@@ -466,8 +1033,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: vscodium"
+        id: check-vscodium
+        env:
+          SYSEXT: vscodium
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: vscodium"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-vscodium.outputs.BUILD == 'true')
         with:
           context: 'vscodium'
           image: ${{ env.DESTINATION }}
@@ -479,8 +1063,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: wireguard-tools"
+        id: check-wireguard-tools
+        env:
+          SYSEXT: wireguard-tools
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: wireguard-tools"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-wireguard-tools.outputs.BUILD == 'true')
         with:
           context: 'wireguard-tools'
           image: ${{ env.DESTINATION }}
@@ -492,8 +1093,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: zoxide"
+        id: check-zoxide
+        env:
+          SYSEXT: zoxide
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: zoxide"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-zoxide.outputs.BUILD == 'true')
         with:
           context: 'zoxide'
           image: ${{ env.DESTINATION }}
@@ -505,8 +1123,25 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: zsh"
+        id: check-zsh
+        env:
+          SYSEXT: zsh
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: zsh"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-zsh.outputs.BUILD == 'true')
         with:
           context: 'zsh'
           image: ${{ env.DESTINATION }}

--- a/.github/workflows/sysexts-fedora-coreos-stable.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable.yml
@@ -331,6 +331,51 @@ jobs:
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: kubernetes-cri-o-1.29"
+        env:
+          SYSEXT: kubernetes-cri-o-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.30"
+        env:
+          SYSEXT: kubernetes-cri-o-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.31"
+        env:
+          SYSEXT: kubernetes-cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: libvirtd"
         env:
           SYSEXT: libvirtd

--- a/.github/workflows/sysexts-fedora-coreos-stable.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable.yml
@@ -6,6 +6,7 @@ env:
   NAME: 'Fedora CoreOS (stable)'
   SHORTNAME: 'fedora-coreos'
   GH_TOKEN: ${{ github.token }}
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -55,11 +56,23 @@ jobs:
         run: |
           mkdir -p artifacts
 
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
       - name: "Build sysext: 1password-cli"
         env:
           SYSEXT: 1password-cli
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -68,6 +81,13 @@ jobs:
           SYSEXT: btop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -76,6 +96,13 @@ jobs:
           SYSEXT: cockpit
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -84,6 +111,13 @@ jobs:
           SYSEXT: compsize
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -92,6 +126,13 @@ jobs:
           SYSEXT: cri-o-1.29
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -100,6 +141,13 @@ jobs:
           SYSEXT: cri-o-1.30
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -108,6 +156,13 @@ jobs:
           SYSEXT: cri-o-1.31
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -116,6 +171,13 @@ jobs:
           SYSEXT: distrobox
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -124,6 +186,13 @@ jobs:
           SYSEXT: erofs-utils
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -132,6 +201,13 @@ jobs:
           SYSEXT: gdb
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -140,6 +216,13 @@ jobs:
           SYSEXT: git-tools
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -148,6 +231,13 @@ jobs:
           SYSEXT: htop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -156,6 +246,13 @@ jobs:
           SYSEXT: incus
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -164,6 +261,13 @@ jobs:
           SYSEXT: iwd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -172,6 +276,13 @@ jobs:
           SYSEXT: just
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -180,6 +291,13 @@ jobs:
           SYSEXT: kubernetes-1.29
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -188,6 +306,13 @@ jobs:
           SYSEXT: kubernetes-1.30
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -196,6 +321,13 @@ jobs:
           SYSEXT: kubernetes-1.31
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -204,6 +336,13 @@ jobs:
           SYSEXT: libvirtd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -212,6 +351,13 @@ jobs:
           SYSEXT: monitoring
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -220,6 +366,13 @@ jobs:
           SYSEXT: mpd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -228,6 +381,13 @@ jobs:
           SYSEXT: neovim
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -236,6 +396,13 @@ jobs:
           SYSEXT: python
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -244,6 +411,13 @@ jobs:
           SYSEXT: ripgrep
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -252,6 +426,13 @@ jobs:
           SYSEXT: semanage
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -260,6 +441,13 @@ jobs:
           SYSEXT: strace
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -268,6 +456,13 @@ jobs:
           SYSEXT: tree
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -276,6 +471,13 @@ jobs:
           SYSEXT: vim
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -284,6 +486,13 @@ jobs:
           SYSEXT: zsh
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 

--- a/.github/workflows/sysexts-fedora-kinoite-41.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41.yml
@@ -6,6 +6,7 @@ env:
   NAME: 'Fedora Kinoite (41)'
   SHORTNAME: 'fedora-kinoite'
   GH_TOKEN: ${{ github.token }}
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -55,11 +56,23 @@ jobs:
         run: |
           mkdir -p artifacts
 
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
       - name: "Build sysext: 1password-cli"
         env:
           SYSEXT: 1password-cli
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -68,6 +81,13 @@ jobs:
           SYSEXT: 1password-gui
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -76,6 +96,13 @@ jobs:
           SYSEXT: btop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -84,6 +111,13 @@ jobs:
           SYSEXT: chromium
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -92,6 +126,13 @@ jobs:
           SYSEXT: compsize
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -100,6 +141,13 @@ jobs:
           SYSEXT: distrobox
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -108,6 +156,13 @@ jobs:
           SYSEXT: docker-ce
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -116,6 +171,13 @@ jobs:
           SYSEXT: emacs
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -124,6 +186,13 @@ jobs:
           SYSEXT: erofs-utils
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -132,6 +201,13 @@ jobs:
           SYSEXT: firefox
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -140,6 +216,13 @@ jobs:
           SYSEXT: fuse2
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -148,6 +231,13 @@ jobs:
           SYSEXT: gdb
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -156,6 +246,13 @@ jobs:
           SYSEXT: git-tools
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -164,6 +261,13 @@ jobs:
           SYSEXT: google-chrome
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -172,6 +276,13 @@ jobs:
           SYSEXT: htop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -180,6 +291,13 @@ jobs:
           SYSEXT: incus
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -188,6 +306,13 @@ jobs:
           SYSEXT: iwd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -196,6 +321,13 @@ jobs:
           SYSEXT: just
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -204,6 +336,13 @@ jobs:
           SYSEXT: keepassxc
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -212,6 +351,13 @@ jobs:
           SYSEXT: krb5-workstation
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -220,6 +366,13 @@ jobs:
           SYSEXT: libvirtd-desktop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -228,6 +381,13 @@ jobs:
           SYSEXT: mesa-git
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -236,6 +396,13 @@ jobs:
           SYSEXT: microsoft-edge
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -244,6 +411,13 @@ jobs:
           SYSEXT: moby-engine
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -252,6 +426,13 @@ jobs:
           SYSEXT: monitoring
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -260,6 +441,13 @@ jobs:
           SYSEXT: mpd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -268,6 +456,13 @@ jobs:
           SYSEXT: mullvad-vpn
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -276,6 +471,13 @@ jobs:
           SYSEXT: neovim
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -284,6 +486,13 @@ jobs:
           SYSEXT: openh264
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -292,6 +501,13 @@ jobs:
           SYSEXT: ripgrep
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -300,6 +516,13 @@ jobs:
           SYSEXT: steam-devices
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -308,6 +531,13 @@ jobs:
           SYSEXT: steam
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -316,6 +546,13 @@ jobs:
           SYSEXT: strace
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -324,6 +561,13 @@ jobs:
           SYSEXT: tree
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -332,6 +576,13 @@ jobs:
           SYSEXT: vim
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -340,6 +591,13 @@ jobs:
           SYSEXT: vscode
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -348,6 +606,13 @@ jobs:
           SYSEXT: vscodium
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -356,6 +621,13 @@ jobs:
           SYSEXT: wireguard-tools
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -364,6 +636,13 @@ jobs:
           SYSEXT: zoxide
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -372,6 +651,13 @@ jobs:
           SYSEXT: zsh
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 

--- a/.github/workflows/sysexts-fedora-silverblue-41.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41.yml
@@ -6,6 +6,7 @@ env:
   NAME: 'Fedora Silverblue (41)'
   SHORTNAME: 'fedora-silverblue'
   GH_TOKEN: ${{ github.token }}
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -55,11 +56,23 @@ jobs:
         run: |
           mkdir -p artifacts
 
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
       - name: "Build sysext: 1password-cli"
         env:
           SYSEXT: 1password-cli
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -68,6 +81,13 @@ jobs:
           SYSEXT: 1password-gui
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -76,6 +96,13 @@ jobs:
           SYSEXT: btop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -84,6 +111,13 @@ jobs:
           SYSEXT: chromium
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -92,6 +126,13 @@ jobs:
           SYSEXT: compsize
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -100,6 +141,13 @@ jobs:
           SYSEXT: distrobox
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -108,6 +156,13 @@ jobs:
           SYSEXT: docker-ce
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -116,6 +171,13 @@ jobs:
           SYSEXT: emacs
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -124,6 +186,13 @@ jobs:
           SYSEXT: erofs-utils
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -132,6 +201,13 @@ jobs:
           SYSEXT: firefox
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -140,6 +216,13 @@ jobs:
           SYSEXT: fuse2
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -148,6 +231,13 @@ jobs:
           SYSEXT: gdb
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -156,6 +246,13 @@ jobs:
           SYSEXT: git-tools
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -164,6 +261,13 @@ jobs:
           SYSEXT: google-chrome
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -172,6 +276,13 @@ jobs:
           SYSEXT: htop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -180,6 +291,13 @@ jobs:
           SYSEXT: incus
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -188,6 +306,13 @@ jobs:
           SYSEXT: iwd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -196,6 +321,13 @@ jobs:
           SYSEXT: just
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -204,6 +336,13 @@ jobs:
           SYSEXT: keepassxc
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -212,6 +351,13 @@ jobs:
           SYSEXT: krb5-workstation
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -220,6 +366,13 @@ jobs:
           SYSEXT: libvirtd-desktop
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -228,6 +381,13 @@ jobs:
           SYSEXT: mesa-git
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -236,6 +396,13 @@ jobs:
           SYSEXT: microsoft-edge
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -244,6 +411,13 @@ jobs:
           SYSEXT: moby-engine
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -252,6 +426,13 @@ jobs:
           SYSEXT: monitoring
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -260,6 +441,13 @@ jobs:
           SYSEXT: mpd
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -268,6 +456,13 @@ jobs:
           SYSEXT: mullvad-vpn
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -276,6 +471,13 @@ jobs:
           SYSEXT: neovim
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -284,6 +486,13 @@ jobs:
           SYSEXT: openh264
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -292,6 +501,13 @@ jobs:
           SYSEXT: ripgrep
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -300,6 +516,13 @@ jobs:
           SYSEXT: steam-devices
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -308,6 +531,13 @@ jobs:
           SYSEXT: steam
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -316,6 +546,13 @@ jobs:
           SYSEXT: strace
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -324,6 +561,13 @@ jobs:
           SYSEXT: tree
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -332,6 +576,13 @@ jobs:
           SYSEXT: vim
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -340,6 +591,13 @@ jobs:
           SYSEXT: vscode
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -348,6 +606,13 @@ jobs:
           SYSEXT: vscodium
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -356,6 +621,13 @@ jobs:
           SYSEXT: wireguard-tools
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -364,6 +636,13 @@ jobs:
           SYSEXT: zoxide
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
@@ -372,6 +651,13 @@ jobs:
           SYSEXT: zsh
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 

--- a/.workflow-templates/containers_build
+++ b/.workflow-templates/containers_build
@@ -1,5 +1,22 @@
+      - name: "Checking if we need to build container: %%SYSEXT%%"
+        id: check-%%SYSEXT_NODOT%%
+        env:
+          SYSEXT: %%SYSEXT%%
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+              else
+                  echo "BUILD=true" >> "$GITHUB_OUTPUT"
+              fi
+          fi
+
       - name: "Build container: %%SYSEXT%%"
         uses: redhat-actions/buildah-build@v2
+        if: (steps.check-%%SYSEXT_NODOT%%.outputs.BUILD == 'true')
         with:
           context: '%%SYSEXT%%'
           image: ${{ env.DESTINATION }}

--- a/.workflow-templates/containers_header
+++ b/.workflow-templates/containers_header
@@ -6,6 +6,7 @@ env:
   NAME: '%%NAME%%'
   REGISTRY: '%%REGISTRY%%'
   DESTINATION: '%%DESTINATION%%'
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -36,3 +37,8 @@ jobs:
 
       - name: Checkout repo
         uses: actions/checkout@v4
+
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main

--- a/.workflow-templates/sysexts_body
+++ b/.workflow-templates/sysexts_body
@@ -3,5 +3,12 @@
           SYSEXT: %%SYSEXT%%
         run: |
           cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
           just build ${IMAGE}
           mv "${SYSEXT}"*".raw" "../artifacts/"

--- a/.workflow-templates/sysexts_header
+++ b/.workflow-templates/sysexts_header
@@ -6,6 +6,7 @@ env:
   NAME: '%%NAME%%'
   SHORTNAME: '%%SHORTNAME%%'
   GH_TOKEN: ${{ github.token }}
+  PR: ${{ github.event_name == 'pull_request' }}
 
 on:
   pull_request:
@@ -54,3 +55,8 @@ jobs:
       - name: "Setup artifacts directory"
         run: |
           mkdir -p artifacts
+
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main

--- a/cri-o-1.29/README.md
+++ b/cri-o-1.29/README.md
@@ -1,0 +1,6 @@
+# cri-o-1.29
+
+CRI-O and cri-tools packages only.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.

--- a/cri-o-1.30/README.md
+++ b/cri-o-1.30/README.md
@@ -1,0 +1,6 @@
+# cri-o-1.30
+
+CRI-O and cri-tools packages only.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.

--- a/cri-o-1.31/README.md
+++ b/cri-o-1.31/README.md
@@ -1,0 +1,6 @@
+# cri-o-1.31
+
+CRI-O and cri-tools packages only.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.

--- a/kubernetes-1.29/README.md
+++ b/kubernetes-1.29/README.md
@@ -1,0 +1,8 @@
+# kubernetes-1.29
+
+Kubernetes packages and direct dependencies only. Needs to be combined with a
+container runtime such as `containerd`, either from Fedora's packages or the
+`docker-ce` sysext.
+
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.
+For CRI-O only, see the `cri-o-<version>` ones.

--- a/kubernetes-1.30/README.md
+++ b/kubernetes-1.30/README.md
@@ -1,0 +1,8 @@
+# kubernetes-1.30
+
+Kubernetes packages and direct dependencies only. Needs to be combined with a
+container runtime such as `containerd`, either from Fedora's packages or the
+`docker-ce` sysext.
+
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.
+For CRI-O only, see the `cri-o-<version>` ones.

--- a/kubernetes-1.31/README.md
+++ b/kubernetes-1.31/README.md
@@ -1,0 +1,8 @@
+# kubernetes-1.31
+
+Kubernetes packages and direct dependencies only. Needs to be combined with a
+container runtime such as `containerd`, either from Fedora's packages or the
+`docker-ce` sysext.
+
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.
+For CRI-O only, see the `cri-o-<version>` ones.

--- a/kubernetes-cri-o-1.29/Containerfile
+++ b/kubernetes-cri-o-1.29/Containerfile
@@ -1,6 +1,7 @@
 FROM baseimage
 
 RUN dnf install -y \
+    --exclude cri-tools \
     cri-o1.29 \
     cri-tools1.29 \
     kubernetes1.29 \

--- a/kubernetes-cri-o-1.29/Containerfile
+++ b/kubernetes-cri-o-1.29/Containerfile
@@ -1,0 +1,11 @@
+FROM baseimage
+
+RUN dnf install -y \
+    cri-o1.29 \
+    cri-tools1.29 \
+    kubernetes1.29 \
+    kubernetes1.29-client \
+    kubernetes1.29-kubeadm \
+    kubernetes1.29-systemd \
+    && \
+    dnf clean all

--- a/kubernetes-cri-o-1.29/README.md
+++ b/kubernetes-cri-o-1.29/README.md
@@ -1,0 +1,6 @@
+# kubernetes-cri-o-1.29
+
+Kubernetes and CRI-O packages in a single system extension.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For cri-o only, see the `cri-o-<version>` ones.

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -1,0 +1,16 @@
+name := "kubernetes-cri-o-1.29"
+packages := "
+cri-o1.29
+cri-tools1.29
+kubernetes1.29
+kubernetes1.29-client
+kubernetes1.29-kubeadm
+kubernetes1.29-systemd
+"
+base_images := "
+quay.io/fedora/fedora-coreos:stable
+"
+
+import '../sysext.just'
+
+all: default

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -7,6 +7,9 @@ kubernetes1.29-client
 kubernetes1.29-kubeadm
 kubernetes1.29-systemd
 "
+exclude_packages := "
+cri-tools
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable
 "

--- a/kubernetes-cri-o-1.30/Containerfile
+++ b/kubernetes-cri-o-1.30/Containerfile
@@ -1,0 +1,11 @@
+FROM baseimage
+
+RUN dnf install -y \
+    cri-o1.30 \
+    cri-tools1.30 \
+    kubernetes1.30 \
+    kubernetes1.30-client \
+    kubernetes1.30-kubeadm \
+    kubernetes1.30-systemd \
+    && \
+    dnf clean all

--- a/kubernetes-cri-o-1.30/Containerfile
+++ b/kubernetes-cri-o-1.30/Containerfile
@@ -1,6 +1,7 @@
 FROM baseimage
 
 RUN dnf install -y \
+    --exclude cri-tools \
     cri-o1.30 \
     cri-tools1.30 \
     kubernetes1.30 \

--- a/kubernetes-cri-o-1.30/README.md
+++ b/kubernetes-cri-o-1.30/README.md
@@ -1,0 +1,6 @@
+# kubernetes-cri-o-1.30
+
+Kubernetes and CRI-O packages in a single system extension.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For cri-o only, see the `cri-o-<version>` ones.

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -7,6 +7,9 @@ kubernetes1.30-client
 kubernetes1.30-kubeadm
 kubernetes1.30-systemd
 "
+exclude_packages := "
+cri-tools
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable
 "

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -1,0 +1,16 @@
+name := "kubernetes-cri-o-1.30"
+packages := "
+cri-o1.30
+cri-tools1.30
+kubernetes1.30
+kubernetes1.30-client
+kubernetes1.30-kubeadm
+kubernetes1.30-systemd
+"
+base_images := "
+quay.io/fedora/fedora-coreos:stable
+"
+
+import '../sysext.just'
+
+all: default

--- a/kubernetes-cri-o-1.31/Containerfile
+++ b/kubernetes-cri-o-1.31/Containerfile
@@ -1,0 +1,11 @@
+FROM baseimage
+
+RUN dnf install -y \
+    cri-o1.31 \
+    cri-tools1.31 \
+    kubernetes1.31 \
+    kubernetes1.31-client \
+    kubernetes1.31-kubeadm \
+    kubernetes1.31-systemd \
+    && \
+    dnf clean all

--- a/kubernetes-cri-o-1.31/Containerfile
+++ b/kubernetes-cri-o-1.31/Containerfile
@@ -1,6 +1,7 @@
 FROM baseimage
 
 RUN dnf install -y \
+    --exclude cri-tools \
     cri-o1.31 \
     cri-tools1.31 \
     kubernetes1.31 \

--- a/kubernetes-cri-o-1.31/README.md
+++ b/kubernetes-cri-o-1.31/README.md
@@ -1,0 +1,6 @@
+# kubernetes-cri-o-1.31
+
+Kubernetes and CRI-O packages in a single system extension.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For cri-o only, see the `cri-o-<version>` ones.

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -1,0 +1,16 @@
+name := "kubernetes-cri-o-1.31"
+packages := "
+cri-o1.31
+cri-tools1.31
+kubernetes1.31
+kubernetes1.31-client
+kubernetes1.31-kubeadm
+kubernetes1.31-systemd
+"
+base_images := "
+quay.io/fedora/fedora-coreos:stable
+"
+
+import '../sysext.just'
+
+all: default

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -7,6 +7,9 @@ kubernetes1.31-client
 kubernetes1.31-kubeadm
 kubernetes1.31-systemd
 "
+exclude_packages := "
+cri-tools
+"
 base_images := "
 quay.io/fedora/fedora-coreos:stable
 "

--- a/sysext.just
+++ b/sysext.just
@@ -28,6 +28,9 @@ pre_commands := ""
 # Install weak dependencies by default
 dnf_weak_deps := ""
 
+# Do not exclude any dependency by default
+exclude_packages := ""
+
 # Default to noarch + current architecture
 arch := "noarch " + arch()
 
@@ -133,6 +136,13 @@ download-rpms target:
     dnf_opts=""
     if [[ "{{dnf_weak_deps}}" == false ]]; then
         dnf_opts="--setopt=install_weak_deps=False"
+    fi
+    if [[ -n "{{exclude_packages}}" ]]; then
+        excluded_packages="$(echo "{{exclude_packages}}" | xargs)"
+        for p in ${excluded_packages}; do
+            echo "➖ Excluding package: ${p}"
+            dnf_opts+=" --exclude=${p}"
+        done
     fi
 
     packages="$(echo "{{packages}}" | xargs)"
@@ -319,6 +329,13 @@ reset-selinux-labels target:
     dnf_opts=""
     if [[ "{{dnf_weak_deps}}" == false ]]; then
         dnf_opts="--setopt=install_weak_deps=False"
+    fi
+    if [[ -n "{{exclude_packages}}" ]]; then
+        excluded_packages="$(echo "{{exclude_packages}}" | xargs)"
+        for p in ${excluded_packages}; do
+            echo "➖ Excluding package: ${p}"
+            dnf_opts+=" --exclude=${p}"
+        done
     fi
 
     pre_commands=""

--- a/sysext.just
+++ b/sysext.just
@@ -333,7 +333,7 @@ reset-selinux-labels target:
             disablerepos+=" --disablerepo=${r}"
         done
     fi
-    
+
     if [[ -n "{{packages}}" ]]; then
         pre_commands+="dnf install -y ${dnf_opts} ${disablerepos} ./rpms/* && "
     fi

--- a/update_workflows.sh
+++ b/update_workflows.sh
@@ -94,7 +94,10 @@ main() {
     echo ""
     for s in "${sysexts[@]}"; do
         if [[ -f "${s}/Containerfile" ]]; then
-            sed "s|%%SYSEXT%%|${s}|g" "${tmpl}/containers_build"
+            sed \
+                -e "s|%%SYSEXT%%|${s}|g" \
+                -e "s|%%SYSEXT_NODOT%%|${s//\./_}|g" \
+                "${tmpl}/containers_build"
             echo ""
         fi
     done


### PR DESCRIPTION
sysext.just: Whitespace cleanup

---

sysext.just: Support excluding packages from weak dependencies

Sometimes needed to exclude some packages while still keeping weak
dependencies enabled globally.

See: https://github.com/travier/fedora-sysexts/pull/45

---

workflows: Only build sysexts on PRs with related changes

See: https://github.com/travier/fedora-sysexts/issues/47

---

kubernetes-cri-o-*: Add initial sysexts

Sysext with both Kubernetes and CRI-O. Might replace the standalone
CRI-O sysext in the future.

---

kubernetes-cri-o-*: Exclude unversioned cri-tools dependency

---

cri-o/kubernetes: Add READMEs