### PR TITLE
Add support for building aarch64 EROFS sysexts

### DIFF
--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -1,0 +1,237 @@
+name: "Build sysexts: Fedora CoreOS (stable) (aarch64)"
+
+env:
+  IMAGE: 'quay.io/fedora/fedora-coreos:stable'
+  RELEASE: 'stable'
+  NAME: 'Fedora CoreOS (stable)'
+  SHORTNAME: 'fedora-coreos'
+  GH_TOKEN: ${{ github.token }}
+  PR: ${{ github.event_name == 'pull_request' }}
+  ARCH: 'aarch64'
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    - cron:  '0 0 * * MON'
+  workflow_dispatch:
+
+# Needed to allow creating a release
+permissions:
+  contents: write
+
+# Prevent multiple workflow runs from racing to ensure that pushes are made
+# sequentialy for the main branch. Also cancel in progress workflow runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ inputs.sysext }}
+
+jobs:
+  build:
+    runs-on: "ubuntu-24.04"
+    container:
+      image: "quay.io/fedora/fedora:41"
+      options: "--privileged --security-opt label=disable --user 0:0 -v /proc/:/host/proc/:rw"
+    steps:
+      - name: "Install tools"
+        run: |
+          dnf install -y \
+            cpio \
+            dnf5-plugins \
+            erofs-utils \
+            git \
+            jq \
+            just \
+            podman \
+            wget
+          dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
+          dnf install -y gh --repo gh-cli
+
+      - name: Setup QEMU for multi-arch builds
+        shell: bash
+        run: |
+          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
+
+      - name: "Checkout repo"
+        uses: actions/checkout@v4
+
+      - name: "Setup artifacts directory"
+        run: |
+          mkdir -p artifacts
+
+      - name: "Mark directory as safe"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+      - name: "Build sysext: cri-o-1.29"
+        env:
+          SYSEXT: cri-o-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: cri-o-1.30"
+        env:
+          SYSEXT: cri-o-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: cri-o-1.31"
+        env:
+          SYSEXT: cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.29"
+        env:
+          SYSEXT: kubernetes-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.30"
+        env:
+          SYSEXT: kubernetes-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.31"
+        env:
+          SYSEXT: kubernetes-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.29"
+        env:
+          SYSEXT: kubernetes-cri-o-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.30"
+        env:
+          SYSEXT: kubernetes-cri-o-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.31"
+        env:
+          SYSEXT: kubernetes-cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: Create a release with a SHA256SUMS manifest and systemd-sysupdate configs
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+          git config --global --add safe.directory "${PWD}"
+
+          cd ./artifacts
+
+          sha256sum *.raw > SHA256SUMS
+
+          sysexts=()
+          for s in $(ls *.raw); do
+              s="${s%-*-x86-64.raw}"
+              s="${s%-*-aarch64.raw}"
+              sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
+          done
+
+          arch=""
+          if [[ "${ARCH}" != "x86_64"]]; then
+              arch="-${ARCH}"
+          fi
+
+          gh release delete \
+            --cleanup-tag \
+            --yes \
+            "${SHORTNAME}-${RELEASE}${arch}" \
+            || true
+
+          # TODO: Handle --latest
+          gh release create \
+            --title "${NAME} sysexts (${ARCH})" \
+            --notes "System extensions for ${NAME} (${ARCH})" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
+            ./*

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -1,4 +1,4 @@
-name: "Build sysexts: Fedora CoreOS (stable)"
+name: "Build sysexts: Fedora CoreOS (stable) (x86_64)"
 
 env:
   IMAGE: 'quay.io/fedora/fedora-coreos:stable'
@@ -7,6 +7,7 @@ env:
   SHORTNAME: 'fedora-coreos'
   GH_TOKEN: ${{ github.token }}
   PR: ${{ github.event_name == 'pull_request' }}
+  ARCH: 'x86_64'
 
 on:
   pull_request:
@@ -33,7 +34,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     container:
       image: "quay.io/fedora/fedora:41"
-      options: "--privileged --security-opt label=disable --user 0:0"
+      options: "--privileged --security-opt label=disable --user 0:0 -v /proc/:/host/proc/:rw"
     steps:
       - name: "Install tools"
         run: |
@@ -48,6 +49,11 @@ jobs:
             wget
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
+
+      - name: Setup QEMU for multi-arch builds
+        shell: bash
+        run: |
+          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
 
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -73,7 +79,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: btop"
@@ -88,7 +94,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: cockpit"
@@ -103,7 +109,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: compsize"
@@ -118,7 +124,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: cri-o-1.29"
@@ -133,7 +139,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: cri-o-1.30"
@@ -148,7 +154,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: cri-o-1.31"
@@ -163,7 +169,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: distrobox"
@@ -178,7 +184,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: erofs-utils"
@@ -193,7 +199,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: gdb"
@@ -208,7 +214,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: git-tools"
@@ -223,7 +229,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: htop"
@@ -238,7 +244,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: incus"
@@ -253,7 +259,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: iwd"
@@ -268,7 +274,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: just"
@@ -283,7 +289,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: kubernetes-1.29"
@@ -298,7 +304,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: kubernetes-1.30"
@@ -313,7 +319,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: kubernetes-1.31"
@@ -328,7 +334,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: kubernetes-cri-o-1.29"
@@ -343,7 +349,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: kubernetes-cri-o-1.30"
@@ -358,7 +364,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: kubernetes-cri-o-1.31"
@@ -373,7 +379,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: libvirtd"
@@ -388,7 +394,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: monitoring"
@@ -403,7 +409,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mpd"
@@ -418,7 +424,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: neovim"
@@ -433,7 +439,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: python"
@@ -448,7 +454,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: ripgrep"
@@ -463,7 +469,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: semanage"
@@ -478,7 +484,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: strace"
@@ -493,7 +499,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: tree"
@@ -508,7 +514,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vim"
@@ -523,7 +529,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: zsh"
@@ -538,7 +544,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: Create a release with a SHA256SUMS manifest and systemd-sysupdate configs
@@ -553,18 +559,24 @@ jobs:
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
+              s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
           done
+
+          arch=""
+          if [[ "${ARCH}" != "x86_64"]]; then
+              arch="-${ARCH}"
+          fi
 
           gh release delete \
             --cleanup-tag \
             --yes \
-            "${SHORTNAME}-${RELEASE}" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
           # TODO: Handle --latest
           gh release create \
-            --title "${NAME} sysexts" \
-            --notes "System extensions for ${NAME}" \
-            "${SHORTNAME}-${RELEASE}" \
+            --title "${NAME} sysexts (${ARCH})" \
+            --notes "System extensions for ${NAME} (${ARCH})" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             ./*

--- a/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
@@ -1,4 +1,4 @@
-name: "Build sysexts: Fedora Kinoite (41)"
+name: "Build sysexts: Fedora Kinoite (41) (x86_64)"
 
 env:
   IMAGE: 'quay.io/fedora-ostree-desktops/kinoite:41'
@@ -7,6 +7,7 @@ env:
   SHORTNAME: 'fedora-kinoite'
   GH_TOKEN: ${{ github.token }}
   PR: ${{ github.event_name == 'pull_request' }}
+  ARCH: 'x86_64'
 
 on:
   pull_request:
@@ -33,7 +34,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     container:
       image: "quay.io/fedora/fedora:41"
-      options: "--privileged --security-opt label=disable --user 0:0"
+      options: "--privileged --security-opt label=disable --user 0:0 -v /proc/:/host/proc/:rw"
     steps:
       - name: "Install tools"
         run: |
@@ -48,6 +49,11 @@ jobs:
             wget
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
+
+      - name: Setup QEMU for multi-arch builds
+        shell: bash
+        run: |
+          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
 
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -73,7 +79,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: 1password-gui"
@@ -88,7 +94,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: btop"
@@ -103,7 +109,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: chromium"
@@ -118,7 +124,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: compsize"
@@ -133,7 +139,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: distrobox"
@@ -148,7 +154,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: docker-ce"
@@ -163,7 +169,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: emacs"
@@ -178,7 +184,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: erofs-utils"
@@ -193,7 +199,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: firefox"
@@ -208,7 +214,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: fuse2"
@@ -223,7 +229,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: gdb"
@@ -238,7 +244,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: git-tools"
@@ -253,7 +259,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: google-chrome"
@@ -268,7 +274,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: htop"
@@ -283,7 +289,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: incus"
@@ -298,7 +304,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: iwd"
@@ -313,7 +319,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: just"
@@ -328,7 +334,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: keepassxc"
@@ -343,7 +349,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: krb5-workstation"
@@ -358,7 +364,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: libvirtd-desktop"
@@ -373,7 +379,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mesa-git"
@@ -388,7 +394,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: microsoft-edge"
@@ -403,7 +409,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: moby-engine"
@@ -418,7 +424,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: monitoring"
@@ -433,7 +439,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mpd"
@@ -448,7 +454,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mullvad-vpn"
@@ -463,7 +469,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: neovim"
@@ -478,7 +484,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: openh264"
@@ -493,7 +499,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: ripgrep"
@@ -508,7 +514,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: steam-devices"
@@ -523,7 +529,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: steam"
@@ -538,7 +544,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: strace"
@@ -553,7 +559,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: tree"
@@ -568,7 +574,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vim"
@@ -583,7 +589,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vscode"
@@ -598,7 +604,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vscodium"
@@ -613,7 +619,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: wireguard-tools"
@@ -628,7 +634,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: zoxide"
@@ -643,7 +649,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: zsh"
@@ -658,7 +664,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: Create a release with a SHA256SUMS manifest and systemd-sysupdate configs
@@ -673,18 +679,24 @@ jobs:
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
+              s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
           done
+
+          arch=""
+          if [[ "${ARCH}" != "x86_64"]]; then
+              arch="-${ARCH}"
+          fi
 
           gh release delete \
             --cleanup-tag \
             --yes \
-            "${SHORTNAME}-${RELEASE}" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
           # TODO: Handle --latest
           gh release create \
-            --title "${NAME} sysexts" \
-            --notes "System extensions for ${NAME}" \
-            "${SHORTNAME}-${RELEASE}" \
+            --title "${NAME} sysexts (${ARCH})" \
+            --notes "System extensions for ${NAME} (${ARCH})" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             ./*

--- a/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
@@ -1,4 +1,4 @@
-name: "Build sysexts: Fedora Silverblue (41)"
+name: "Build sysexts: Fedora Silverblue (41) (x86_64)"
 
 env:
   IMAGE: 'quay.io/fedora-ostree-desktops/silverblue:41'
@@ -7,6 +7,7 @@ env:
   SHORTNAME: 'fedora-silverblue'
   GH_TOKEN: ${{ github.token }}
   PR: ${{ github.event_name == 'pull_request' }}
+  ARCH: 'x86_64'
 
 on:
   pull_request:
@@ -33,7 +34,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     container:
       image: "quay.io/fedora/fedora:41"
-      options: "--privileged --security-opt label=disable --user 0:0"
+      options: "--privileged --security-opt label=disable --user 0:0 -v /proc/:/host/proc/:rw"
     steps:
       - name: "Install tools"
         run: |
@@ -48,6 +49,11 @@ jobs:
             wget
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
+
+      - name: Setup QEMU for multi-arch builds
+        shell: bash
+        run: |
+          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
 
       - name: "Checkout repo"
         uses: actions/checkout@v4
@@ -73,7 +79,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: 1password-gui"
@@ -88,7 +94,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: btop"
@@ -103,7 +109,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: chromium"
@@ -118,7 +124,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: compsize"
@@ -133,7 +139,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: distrobox"
@@ -148,7 +154,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: docker-ce"
@@ -163,7 +169,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: emacs"
@@ -178,7 +184,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: erofs-utils"
@@ -193,7 +199,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: firefox"
@@ -208,7 +214,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: fuse2"
@@ -223,7 +229,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: gdb"
@@ -238,7 +244,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: git-tools"
@@ -253,7 +259,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: google-chrome"
@@ -268,7 +274,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: htop"
@@ -283,7 +289,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: incus"
@@ -298,7 +304,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: iwd"
@@ -313,7 +319,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: just"
@@ -328,7 +334,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: keepassxc"
@@ -343,7 +349,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: krb5-workstation"
@@ -358,7 +364,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: libvirtd-desktop"
@@ -373,7 +379,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mesa-git"
@@ -388,7 +394,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: microsoft-edge"
@@ -403,7 +409,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: moby-engine"
@@ -418,7 +424,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: monitoring"
@@ -433,7 +439,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mpd"
@@ -448,7 +454,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: mullvad-vpn"
@@ -463,7 +469,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: neovim"
@@ -478,7 +484,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: openh264"
@@ -493,7 +499,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: ripgrep"
@@ -508,7 +514,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: steam-devices"
@@ -523,7 +529,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: steam"
@@ -538,7 +544,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: strace"
@@ -553,7 +559,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: tree"
@@ -568,7 +574,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vim"
@@ -583,7 +589,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vscode"
@@ -598,7 +604,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: vscodium"
@@ -613,7 +619,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: wireguard-tools"
@@ -628,7 +634,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: zoxide"
@@ -643,7 +649,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: "Build sysext: zsh"
@@ -658,7 +664,7 @@ jobs:
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
       - name: Create a release with a SHA256SUMS manifest and systemd-sysupdate configs
@@ -673,18 +679,24 @@ jobs:
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
+              s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
           done
+
+          arch=""
+          if [[ "${ARCH}" != "x86_64"]]; then
+              arch="-${ARCH}"
+          fi
 
           gh release delete \
             --cleanup-tag \
             --yes \
-            "${SHORTNAME}-${RELEASE}" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
           # TODO: Handle --latest
           gh release create \
-            --title "${NAME} sysexts" \
-            --notes "System extensions for ${NAME}" \
-            "${SHORTNAME}-${RELEASE}" \
+            --title "${NAME} sysexts (${ARCH})" \
+            --notes "System extensions for ${NAME} (${ARCH})" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             ./*

--- a/.workflow-templates/sysexts_body
+++ b/.workflow-templates/sysexts_body
@@ -10,5 +10,5 @@
                   exit 0
               fi
           fi
-          just build ${IMAGE}
+          just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"

--- a/.workflow-templates/sysexts_footer
+++ b/.workflow-templates/sysexts_footer
@@ -10,18 +10,24 @@
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
+              s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
           done
+
+          arch=""
+          if [[ "${ARCH}" != "x86_64"]]; then
+              arch="-${ARCH}"
+          fi
 
           gh release delete \
             --cleanup-tag \
             --yes \
-            "${SHORTNAME}-${RELEASE}" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
           # TODO: Handle --latest
           gh release create \
-            --title "${NAME} sysexts" \
-            --notes "System extensions for ${NAME}" \
-            "${SHORTNAME}-${RELEASE}" \
+            --title "${NAME} sysexts (${ARCH})" \
+            --notes "System extensions for ${NAME} (${ARCH})" \
+            "${SHORTNAME}-${RELEASE}${arch}" \
             ./*

--- a/.workflow-templates/sysexts_header
+++ b/.workflow-templates/sysexts_header
@@ -1,4 +1,4 @@
-name: "Build sysexts: %%NAME%%"
+name: "Build sysexts: %%NAME%% (%%ARCH%%)"
 
 env:
   IMAGE: '%%IMAGE%%'
@@ -7,6 +7,7 @@ env:
   SHORTNAME: '%%SHORTNAME%%'
   GH_TOKEN: ${{ github.token }}
   PR: ${{ github.event_name == 'pull_request' }}
+  ARCH: '%%ARCH%%'
 
 on:
   pull_request:
@@ -33,7 +34,7 @@ jobs:
     runs-on: "ubuntu-24.04"
     container:
       image: "quay.io/fedora/fedora:41"
-      options: "--privileged --security-opt label=disable --user 0:0"
+      options: "--privileged --security-opt label=disable --user 0:0 -v /proc/:/host/proc/:rw"
     steps:
       - name: "Install tools"
         run: |
@@ -48,6 +49,11 @@ jobs:
             wget
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
+
+      - name: Setup QEMU for multi-arch builds
+        shell: bash
+        run: |
+          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
 
       - name: "Checkout repo"
         uses: actions/checkout@v4

--- a/1password-cli/justfile
+++ b/1password-cli/justfile
@@ -10,7 +10,7 @@ import '../sysext.just'
 
 all: default
 
-download-manual:
+download-manual arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x

--- a/1password-gui/justfile
+++ b/1password-gui/justfile
@@ -10,7 +10,7 @@ import '../sysext.just'
 
 all: default
 
-download-manual:
+download-manual arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x

--- a/cri-o-1.29/justfile
+++ b/cri-o-1.29/justfile
@@ -4,7 +4,7 @@ cri-o1.29
 cri-tools1.29
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/cri-o-1.30/justfile
+++ b/cri-o-1.30/justfile
@@ -4,7 +4,7 @@ cri-o1.30
 cri-tools1.30
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/cri-o-1.31/justfile
+++ b/cri-o-1.31/justfile
@@ -4,7 +4,7 @@ cri-o1.31
 cri-tools1.31
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.29/justfile
+++ b/kubernetes-1.29/justfile
@@ -6,7 +6,7 @@ kubernetes1.29-kubeadm
 kubernetes1.29-systemd
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.30/justfile
+++ b/kubernetes-1.30/justfile
@@ -6,7 +6,7 @@ kubernetes1.30-kubeadm
 kubernetes1.30-systemd
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.31/justfile
+++ b/kubernetes-1.31/justfile
@@ -6,7 +6,7 @@ kubernetes1.31-kubeadm
 kubernetes1.31-systemd
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -11,7 +11,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -11,7 +11,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -11,7 +11,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/monitoring/justfile
+++ b/monitoring/justfile
@@ -15,7 +15,7 @@ import '../sysext.just'
 all: default
 
 # Custom download step to get bandwhich
-download-manual:
+download-manual arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x

--- a/steam-devices/justfile
+++ b/steam-devices/justfile
@@ -1,7 +1,7 @@
 name := "steam-devices"
 packages := "steam-devices"
 enable_repos := "rpmfusion-nonfree-steam"
-arch := "i686"
+dnf_arch := "i686"
 base_images := "
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41

--- a/steam/justfile
+++ b/steam/justfile
@@ -1,7 +1,7 @@
 name := "steam"
 packages := "steam"
 enable_repos := "rpmfusion-nonfree-steam"
-arch := "noarch i686 x86_64"
+dnf_arch := "noarch i686 x86_64"
 base_images := "
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41

--- a/sysext.just
+++ b/sysext.just
@@ -53,7 +53,19 @@ default:
     echo "{{base_images}}"
 
 # Main recipe with all the steps to use to build a sysext
-build target: (check target) clean (download-rpms target) download-manual setup-rootfs install-rpms install-files install-manual move-etc rm-ignored (reset-selinux-labels target) (build-erofs target)
+build target: \
+    (check target) \
+    clean \
+    (download-rpms target) \
+    download-manual \
+    setup-rootfs \
+    install-rpms \
+    install-files \
+    install-manual \
+    move-etc \
+    rm-ignored \
+    (reset-selinux-labels target) \
+    (build-erofs target)
 
 # List the supported targets for this sysext. To use in CI and scripting
 targets:

--- a/sysext.just
+++ b/sysext.just
@@ -7,6 +7,9 @@ set allow-duplicate-recipes := true
 # sysexts must explicitely say which base operating system images they target
 base_images := ""
 
+# Default to building for the current architecture
+arch := arch()
+
 # Do not download any packages by default
 packages := ""
 
@@ -53,19 +56,19 @@ default:
     echo "{{base_images}}"
 
 # Main recipe with all the steps to use to build a sysext
-build target: \
-    (check target) \
+build target arch=arch: \
+    (check target arch) \
     clean \
-    (download-rpms target) \
-    download-manual \
-    setup-rootfs \
+    (download-rpms target arch) \
+    (download-manual arch) \
+    (setup-rootfs arch) \
     install-rpms \
     install-files \
     install-manual \
     move-etc \
     rm-ignored \
-    (reset-selinux-labels target) \
-    (build-erofs target)
+    (reset-selinux-labels target arch) \
+    (build-erofs target arch)
 
 # List the supported targets for this sysext. To use in CI and scripting
 targets:
@@ -81,7 +84,7 @@ targets:
     echo "{{base_images}}" | xargs
 
 # Sanity check that some variables are set
-check target:
+check target arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
@@ -94,14 +97,51 @@ check target:
 
     # Make sure that the current target is in the supported list
     found=false
-    for base in $(echo "{{base_images}}" | xargs); do
-        if [[ "${base}" == {{target}} ]]; then
-            found=true
-            break
+    mapfile -t baseimages <<< "{{base_images}}"
+    for base in "${baseimages[@]}"; do
+        if [[ -z "${base}" ]]; then
+            continue
+        fi
+        # echo "Checking against: $base"
+        # Split on whitespace
+        baseimage=($base)
+        if [[ "${baseimage[0]}" == {{target}} ]]; then
+            # echo "Base image name matched: ${baseimage[0]}"
+            # Ignore architecture check if nothing is specified and architecture is x86_64
+            # echo "${baseimage[@]} ${#baseimage[@]}"
+            if [[ "${#baseimage[@]}" -eq 1 ]]; then
+                # echo "No architecture set for base image"
+                if [[ "{{arch}}" == "x86_64" ]]; then
+                    found=true
+                    break
+                fi
+                # Otherwise skip this entry as we can not be sure it's supported
+                # echo "Potentially unsupported arch for this image: {{arch}}"
+                break
+            fi
+            IFS=','
+            # Check if the architecture is in the list
+            read -ra arches <<< "${baseimage[1]}"
+            unset IFS
+            # echo "Architectures available: ${arches[@]}"
+            for a in "${arches[@]}"; do
+                # echo "Looking at: ${a}"
+                if [[ "${a}" == "{{arch}}" ]]; then
+                    found=true
+                    break
+                fi
+            done
+            # Break again out of the loop if found
+            if [[ "${found}" == true ]]; then
+                break
+            fi
         fi
     done
     if [[ ${found} == "false" ]]; then
-        echo "{{target}} is not listed as a supported base image for this sysext"
+        echo "{{target}} {{arch}} is not listed as a supported base image for this sysext"
+        echo ""
+        echo "Valid targets for this sysext:"
+        echo "{{base_images}}"
         exit 1
     fi
 
@@ -114,7 +154,7 @@ check target:
 # Download RPMs to install. Use the following variables:
 # - packages: List of packages to download (and later install)
 # - enable_repos: List of additional repos to enable
-download-rpms target:
+download-rpms target arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
@@ -191,6 +231,7 @@ download-rpms target:
     echo "⬇️ Downloading packages (${dnf_arches}): ${packages}"
     # dnf install --downloadonly --downloaddir . ${dnf_arch} ${enablerepos} ${packages}
     podman run --rm -ti \
+        --arch={{arch}} \
         --volume "${PWD}:/var/srv" \
         --volume "${PWD}/../../.dnf-cache:/var/cache/libdnf5" \
         --workdir "/var/srv" \
@@ -199,14 +240,14 @@ download-rpms target:
         bash -c "${pre_commands}dnf download --resolve ${dnf_arch} ${dnf_opts} ${disablerepos} ${enablerepos} ${packages}"
 
 # Manual download step, that can be overridden to dowload non RPM content
-download-manual:
+download-manual arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
     exit 0
 
 # Sets up the rootfs directory and creates the extension release config
-setup-rootfs:
+setup-rootfs arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
@@ -222,7 +263,10 @@ setup-rootfs:
 
     echo "➡️ Setting up extension config file"
     ${SUDO} install -d -m0755 usr/lib/extension-release.d
-    echo "ID=\"_any\"" | ${SUDO} tee usr/lib/extension-release.d/extension-release.{{name}} > /dev/null
+    {
+    echo "ID=\"_any\""
+    echo "ARCHITECTURE=\"{{arch}}\""
+    } | ${SUDO} tee "usr/lib/extension-release.d/extension-release.{{name}}" > /dev/null
 
 # Install (extract) RPM packages download in download-rpms recipe. Uses:
 # - packages: List of packages to install
@@ -332,7 +376,7 @@ rm-ignored:
     done
 
 # Reset SELinux labels to expected values from the policy
-reset-selinux-labels target:
+reset-selinux-labels target arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
@@ -375,6 +419,7 @@ reset-selinux-labels target:
     filecontexts="/etc/selinux/targeted/contexts/files/file_contexts"
     echo "🏷️ Resetting SELinux labels"
     podman run --rm -ti \
+        --arch={{arch}} \
         --volume "${PWD}:/var/srv" \
         --volume "${PWD}/../.dnf-cache:/var/cache/libdnf5" \
         --workdir "/var/srv" \
@@ -384,7 +429,7 @@ reset-selinux-labels target:
         bash -c "${pre_commands}cd rootfs && setfiles -r . ${filecontexts} . && chcon --user=system_u --recursive ."
 
 # Creates the EROFS sysext file
-build-erofs target:
+build-erofs target arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
@@ -397,10 +442,12 @@ build-erofs target:
 
     echo "🔒 Creating EROFS sysext ({{compression}})"
     version=$(podman run --rm -ti \
+        --arch={{arch}} \
         --security-opt label=disable \
         "{{target}}" \
         bash -c 'source /etc/os-release ; echo -n ${OSTREE_VERSION}')
-    arch=$(uname -m | sed 's/_/-/g')
+    # Post process architecture to match systemd architecture list
+    arch="$(echo {{arch}} | sed 's/_/-/g')"
     ${SUDO} mkfs.erofs -z{{compression}} {{name}}-${version}-${arch}.raw rootfs > /dev/null
 
     if [[ "${UID}" != "0" ]]; then

--- a/sysext.just
+++ b/sysext.just
@@ -32,7 +32,7 @@ dnf_weak_deps := ""
 exclude_packages := ""
 
 # Default to noarch + current architecture
-arch := "noarch " + arch()
+dnf_arch := ""
 
 # Do not install any additional files by default
 files := ""
@@ -128,9 +128,14 @@ download-rpms target:
         done
     fi
 
-    arch=""
-    for a in {{arch}}; do
-        arch+="--arch=${a} "
+    dnf_arch=""
+    if [[ -z "{{dnf_arch}}" ]]; then
+        dnf_arches="noarch {{arch}}"
+    else
+        dnf_arches="{{dnf_arch}}"
+    fi
+    for a in ${dnf_arches}; do
+        dnf_arch+="--arch=${a} "
     done
 
     dnf_opts=""
@@ -171,15 +176,15 @@ download-rpms target:
     mkdir rpms
     cd rpms
 
-    echo "⬇️ Downloading packages ({{arch}}): ${packages}"
-    # dnf install --downloadonly --downloaddir . ${arch} ${enablerepos} ${packages}
+    echo "⬇️ Downloading packages (${dnf_arches}): ${packages}"
+    # dnf install --downloadonly --downloaddir . ${dnf_arch} ${enablerepos} ${packages}
     podman run --rm -ti \
         --volume "${PWD}:/var/srv" \
         --volume "${PWD}/../../.dnf-cache:/var/cache/libdnf5" \
         --workdir "/var/srv" \
         --security-opt label=disable \
         "{{target}}" \
-        bash -c "${pre_commands}dnf download --resolve ${arch} ${dnf_opts} ${disablerepos} ${enablerepos} ${packages}"
+        bash -c "${pre_commands}dnf download --resolve ${dnf_arch} ${dnf_opts} ${disablerepos} ${enablerepos} ${packages}"
 
 # Manual download step, that can be overridden to dowload non RPM content
 download-manual:

--- a/update_workflows.sh
+++ b/update_workflows.sh
@@ -21,6 +21,15 @@ main() {
             'fedora-coreos-sysexts'
 
         ${0} \
+            'quay.io/fedora/fedora-coreos' \
+            'stable' \
+            'aarch64' \
+            'Fedora CoreOS (stable)' \
+            'fedora-coreos' \
+            'quay.io/travier' \
+            'fedora-coreos-sysexts'
+
+        ${0} \
             'quay.io/fedora-ostree-desktops/kinoite' \
             '41' \
             'x86_64' \

--- a/vscodium/justfile
+++ b/vscodium/justfile
@@ -10,7 +10,7 @@ import '../sysext.just'
 all: default
 
 # Custom download step to get VSCodium RPM
-download-rpms target:
+download-rpms target arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x


### PR DESCRIPTION
sysext.just: Rename 'arch' to 'dnf_arch' for dnf download

Split the list of architectures to use with dnf when downloading
packages from the global architecture to build the sysext for.

---

sysext.just: Split build recipe dependency list

---

sysext.just: Support building for non native architectures

Update justfiles to new recipe signature.

---

kubernetes/cri-o: Also build for aarch64

---

workflows: Add support for non x86_64 architectures

---

workflows: Add aarch64 sysexts build for Fedora CoreOS

---

See: https://github.com/travier/fedora-sysexts/issues/49