### PR TITLE
fix: emacs used alternatives, fix symlinks

### DIFF
--- a/emacs/Containerfile
+++ b/emacs/Containerfile
@@ -3,4 +3,16 @@ FROM baseimage
 RUN dnf install -y --setopt=install_weak_deps=False \
     emacs \
     && \
+    EMACS_PATH="/usr/bin/emacs-pgtk" \
+    && \
+    ETAGS_PATH="/usr/bin/emacs.etags" \
+    && \
+    ETAGS_MAN_PATH="/usr/share/man/man1/etags.emacs.1.gz" \
+    && \
+    ln -sf "$EMACS_PATH" "/usr/bin/emacs" \
+    && \
+    ln -sf "$ETAGS_PATH" "/usr/bin/etags" \
+    && \
+    ln -sf "$ETAGS_MAN_PATH" "/usr/share/man/man1/etags.1.gz" \
+    && \
     dnf clean all

--- a/emacs/justfile
+++ b/emacs/justfile
@@ -9,3 +9,23 @@ quay.io/fedora-ostree-desktops/kinoite:41
 import '../sysext.just'
 
 all: default
+
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    set -x
+
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
+    cd rootfs
+
+    EMACS_PATH="/usr/bin/emacs-pgtk"
+    ETAGS_PATH="/usr/bin/emacs.etags"
+    ETAGS_MAN_PATH="/usr/share/man/man1/etags.emacs.1.gz"
+    ${SUDO} ln -sf "$EMACS_PATH" "usr/bin/emacs"
+    ${SUDO} ln -sf "$ETAGS_PATH" "usr/bin/etags"
+    ${SUDO} ln -sf "$ETAGS_MAN_PATH" "usr/share/man/man1/etags.1.gz"


### PR DESCRIPTION
Emacs uses alternatives via /etc/alternatives/. This does not propagate into the sysext.