### PR TITLE
Fix sysupdate config for FCOS and use GitHub aarch64 runners

### DIFF
--- a/.github/workflows/containers-fedora-coreos-stable.yml
+++ b/.github/workflows/containers-fedora-coreos-stable.yml
@@ -254,6 +254,36 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: cri-o-1.32"
+        id: check-cri-o-1_32
+        env:
+          SYSEXT: cri-o-1.32
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+                  exit 0
+              fi
+          fi
+          echo "BUILD=true" >> "$GITHUB_OUTPUT"
+
+      - name: "Build container: cri-o-1.32"
+        uses: redhat-actions/buildah-build@v2
+        if: (steps.check-cri-o-1_32.outputs.BUILD == 'true')
+        with:
+          context: 'cri-o-1.32'
+          image: ${{ env.DESTINATION }}
+          tags: ${{ env.RELEASE }}.cri-o-1.32
+          containerfiles: 'cri-o-1.32/Containerfile'
+          layers: false
+          oci: true
+          extra-args:
+            --from
+            ${{ env.IMAGE }}:${{ env.RELEASE }}
+
       - name: "Checking if we need to build container: distrobox"
         id: check-distrobox
         env:
@@ -704,6 +734,36 @@ jobs:
             --from
             ${{ env.IMAGE }}:${{ env.RELEASE }}
 
+      - name: "Checking if we need to build container: kubernetes-cri-o-1.32"
+        id: check-kubernetes-cri-o-1_32
+        env:
+          SYSEXT: kubernetes-cri-o-1.32
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- .)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  echo "BUILD=false" >> "$GITHUB_OUTPUT"
+                  exit 0
+              fi
+          fi
+          echo "BUILD=true" >> "$GITHUB_OUTPUT"
+
+      - name: "Build container: kubernetes-cri-o-1.32"
+        uses: redhat-actions/buildah-build@v2
+        if: (steps.check-kubernetes-cri-o-1_32.outputs.BUILD == 'true')
+        with:
+          context: 'kubernetes-cri-o-1.32'
+          image: ${{ env.DESTINATION }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.32
+          containerfiles: 'kubernetes-cri-o-1.32/Containerfile'
+          layers: false
+          oci: true
+          extra-args:
+            --from
+            ${{ env.IMAGE }}:${{ env.RELEASE }}
+
       - name: "Checking if we need to build container: libvirtd"
         id: check-libvirtd
         env:
@@ -1148,6 +1208,25 @@ jobs:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
+      - name: "Push container: cri-o-1.32"
+        uses: redhat-actions/push-to-registry@v2
+        id: push-cri-o-1_32
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.DESTINATION }}
+          registry: ${{ env.REGISTRY }}
+          tags: ${{ env.RELEASE }}.cri-o-1.32
+
+      - name: "Sign container: cri-o-1.32"
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-cri-o-1_32.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
       - name: "Push container: distrobox"
         uses: redhat-actions/push-to-registry@v2
         id: push-distrobox
@@ -1429,6 +1508,25 @@ jobs:
         if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-kubernetes-cri-o-1_31.outputs.digest }}
+        env:
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+
+      - name: "Push container: kubernetes-cri-o-1.32"
+        uses: redhat-actions/push-to-registry@v2
+        id: push-kubernetes-cri-o-1_32
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        with:
+          username: ${{ secrets.BOT_USERNAME }}
+          password: ${{ secrets.BOT_SECRET }}
+          image: ${{ env.DESTINATION }}
+          registry: ${{ env.REGISTRY }}
+          tags: ${{ env.RELEASE }}.kubernetes-cri-o-1.32
+
+      - name: "Sign container: kubernetes-cri-o-1.32"
+        if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY }}/${{ env.DESTINATION }}@${{ steps.push-kubernetes-cri-o-1_32.outputs.digest }}
         env:
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -122,17 +122,20 @@ jobs:
 
           sha256sum *.raw > SHA256SUMS
 
+          arch=""
+          if [[ "${ARCH}" != "x86_64" ]]; then
+              arch="-${ARCH}"
+          fi
+
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
               s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
+              if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+                  sed -i "s/%w/stable${arch}/" ${s}.conf
+              fi
           done
-
-          arch=""
-          if [[ "${ARCH}" != "x86_64" ]]; then
-              arch="-${ARCH}"
-          fi
 
           gh release delete \
             --cleanup-tag \

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -138,6 +138,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: cri-o-1.32"
+        env:
+          SYSEXT: cri-o-1.32
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: distrobox"
         env:
           SYSEXT: distrobox
@@ -351,6 +366,21 @@ jobs:
       - name: "Build sysext: kubernetes-cri-o-1.31"
         env:
           SYSEXT: kubernetes-cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.32"
+        env:
+          SYSEXT: kubernetes-cri-o-1.32
         run: |
           cd "${SYSEXT}"
           if [[ "${PR}" == "true" ]]; then

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: "ubuntu-24.04"
+    runs-on: "ubuntu-24.04-arm"
     container:
       image: "quay.io/fedora/fedora:41"
       options: "--privileged --security-opt label=disable --user 0:0 -v /proc/:/host/proc/:rw"
@@ -50,11 +50,6 @@ jobs:
             wget
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
-
-      - name: Setup QEMU for multi-arch builds
-        shell: bash
-        run: |
-          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
 
       - name: "Checkout repo"
         uses: actions/checkout@v4

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -140,9 +140,13 @@ jobs:
             "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
-          # TODO: Handle --latest
+          latest=false
+          if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+            latest="true"
+          fi
           gh release create \
             --title "${NAME} sysexts (${ARCH})" \
             --notes "System extensions for ${NAME} (${ARCH})" \
             "${SHORTNAME}-${RELEASE}${arch}" \
+            --latest=${latest} \
             ./*

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -63,6 +63,261 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git fetch --no-tags --prune --depth=1 origin +refs/heads/main:refs/remotes/origin/main
 
+      - name: "Build sysext: btop"
+        env:
+          SYSEXT: btop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: compsize"
+        env:
+          SYSEXT: compsize
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: cri-o-1.29"
+        env:
+          SYSEXT: cri-o-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: cri-o-1.30"
+        env:
+          SYSEXT: cri-o-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: cri-o-1.31"
+        env:
+          SYSEXT: cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: distrobox"
+        env:
+          SYSEXT: distrobox
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: erofs-utils"
+        env:
+          SYSEXT: erofs-utils
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: gdb"
+        env:
+          SYSEXT: gdb
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: git-tools"
+        env:
+          SYSEXT: git-tools
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: htop"
+        env:
+          SYSEXT: htop
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: incus"
+        env:
+          SYSEXT: incus
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: iwd"
+        env:
+          SYSEXT: iwd
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: just"
+        env:
+          SYSEXT: just
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.29"
+        env:
+          SYSEXT: kubernetes-1.29
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.30"
+        env:
+          SYSEXT: kubernetes-1.30
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.31"
+        env:
+          SYSEXT: kubernetes-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-1.32"
+        env:
+          SYSEXT: kubernetes-1.32
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: kubernetes-cri-o-1.29"
         env:
           SYSEXT: kubernetes-cri-o-1.29
@@ -96,6 +351,141 @@ jobs:
       - name: "Build sysext: kubernetes-cri-o-1.31"
         env:
           SYSEXT: kubernetes-cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: mpd"
+        env:
+          SYSEXT: mpd
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: neovim"
+        env:
+          SYSEXT: neovim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: python"
+        env:
+          SYSEXT: python
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: ripgrep"
+        env:
+          SYSEXT: ripgrep
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: semanage"
+        env:
+          SYSEXT: semanage
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: strace"
+        env:
+          SYSEXT: strace
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: tree"
+        env:
+          SYSEXT: tree
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: vim"
+        env:
+          SYSEXT: vim
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: zsh"
+        env:
+          SYSEXT: zsh
         run: |
           cd "${SYSEXT}"
           if [[ "${PR}" == "true" ]]; then

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -572,17 +572,20 @@ jobs:
 
           sha256sum *.raw > SHA256SUMS
 
+          arch=""
+          if [[ "${ARCH}" != "x86_64" ]]; then
+              arch="-${ARCH}"
+          fi
+
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
               s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
+              if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+                  sed -i "s/%w/stable${arch}/" ${s}.conf
+              fi
           done
-
-          arch=""
-          if [[ "${ARCH}" != "x86_64" ]]; then
-              arch="-${ARCH}"
-          fi
 
           gh release delete \
             --cleanup-tag \

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -51,11 +51,6 @@ jobs:
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
 
-      - name: Setup QEMU for multi-arch builds
-        shell: bash
-        run: |
-          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
-
       - name: "Checkout repo"
         uses: actions/checkout@v4
 

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -168,6 +168,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: cri-o-1.32"
+        env:
+          SYSEXT: cri-o-1.32
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: distrobox"
         env:
           SYSEXT: distrobox
@@ -381,6 +396,21 @@ jobs:
       - name: "Build sysext: kubernetes-cri-o-1.31"
         env:
           SYSEXT: kubernetes-cri-o-1.31
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
+      - name: "Build sysext: kubernetes-cri-o-1.32"
+        env:
+          SYSEXT: kubernetes-cri-o-1.32
         run: |
           cd "${SYSEXT}"
           if [[ "${PR}" == "true" ]]; then

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -590,9 +590,13 @@ jobs:
             "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
-          # TODO: Handle --latest
+          latest=false
+          if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+            latest="true"
+          fi
           gh release create \
             --title "${NAME} sysexts (${ARCH})" \
             --notes "System extensions for ${NAME} (${ARCH})" \
             "${SHORTNAME}-${RELEASE}${arch}" \
+            --latest=${latest} \
             ./*

--- a/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
@@ -51,11 +51,6 @@ jobs:
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
 
-      - name: Setup QEMU for multi-arch builds
-        shell: bash
-        run: |
-          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
-
       - name: "Checkout repo"
         uses: actions/checkout@v4
 

--- a/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
@@ -710,9 +710,13 @@ jobs:
             "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
-          # TODO: Handle --latest
+          latest=false
+          if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+            latest="true"
+          fi
           gh release create \
             --title "${NAME} sysexts (${ARCH})" \
             --notes "System extensions for ${NAME} (${ARCH})" \
             "${SHORTNAME}-${RELEASE}${arch}" \
+            --latest=${latest} \
             ./*

--- a/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
@@ -692,17 +692,20 @@ jobs:
 
           sha256sum *.raw > SHA256SUMS
 
+          arch=""
+          if [[ "${ARCH}" != "x86_64" ]]; then
+              arch="-${ARCH}"
+          fi
+
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
               s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
+              if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+                  sed -i "s/%w/stable${arch}/" ${s}.conf
+              fi
           done
-
-          arch=""
-          if [[ "${ARCH}" != "x86_64" ]]; then
-              arch="-${ARCH}"
-          fi
 
           gh release delete \
             --cleanup-tag \

--- a/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
@@ -51,11 +51,6 @@ jobs:
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
 
-      - name: Setup QEMU for multi-arch builds
-        shell: bash
-        run: |
-          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
-
       - name: "Checkout repo"
         uses: actions/checkout@v4
 

--- a/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
@@ -710,9 +710,13 @@ jobs:
             "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
-          # TODO: Handle --latest
+          latest=false
+          if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+            latest="true"
+          fi
           gh release create \
             --title "${NAME} sysexts (${ARCH})" \
             --notes "System extensions for ${NAME} (${ARCH})" \
             "${SHORTNAME}-${RELEASE}${arch}" \
+            --latest=${latest} \
             ./*

--- a/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
@@ -692,17 +692,20 @@ jobs:
 
           sha256sum *.raw > SHA256SUMS
 
+          arch=""
+          if [[ "${ARCH}" != "x86_64" ]]; then
+              arch="-${ARCH}"
+          fi
+
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
               s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
+              if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+                  sed -i "s/%w/stable${arch}/" ${s}.conf
+              fi
           done
-
-          arch=""
-          if [[ "${ARCH}" != "x86_64" ]]; then
-              arch="-${ARCH}"
-          fi
 
           gh release delete \
             --cleanup-tag \

--- a/.workflow-templates/sysexts_footer
+++ b/.workflow-templates/sysexts_footer
@@ -25,9 +25,13 @@
             "${SHORTNAME}-${RELEASE}${arch}" \
             || true
 
-          # TODO: Handle --latest
+          latest=false
+          if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+            latest="true"
+          fi
           gh release create \
             --title "${NAME} sysexts (${ARCH})" \
             --notes "System extensions for ${NAME} (${ARCH})" \
             "${SHORTNAME}-${RELEASE}${arch}" \
+            --latest=${latest} \
             ./*

--- a/.workflow-templates/sysexts_footer
+++ b/.workflow-templates/sysexts_footer
@@ -7,17 +7,20 @@
 
           sha256sum *.raw > SHA256SUMS
 
+          arch=""
+          if [[ "${ARCH}" != "x86_64" ]]; then
+              arch="-${ARCH}"
+          fi
+
           sysexts=()
           for s in $(ls *.raw); do
               s="${s%-*-x86-64.raw}"
               s="${s%-*-aarch64.raw}"
               sed "s/%%SYSEXT%%/${s}/g" ../.workflow-templates/systemd-sysupdate.conf > ${s}.conf
+              if [[ "${SHORTNAME}" == "fedora-coreos" ]]; then
+                  sed -i "s/%w/stable${arch}/" ${s}.conf
+              fi
           done
-
-          arch=""
-          if [[ "${ARCH}" != "x86_64" ]]; then
-              arch="-${ARCH}"
-          fi
 
           gh release delete \
             --cleanup-tag \

--- a/.workflow-templates/sysexts_header
+++ b/.workflow-templates/sysexts_header
@@ -51,11 +51,6 @@ jobs:
           dnf config-manager addrepo --from-repofile="https://cli.github.com/packages/rpm/gh-cli.repo"
           dnf install -y gh --repo gh-cli
 
-      - name: Setup QEMU for multi-arch builds
-        shell: bash
-        run: |
-          for f in /usr/lib/binfmt.d/*; do cat $f | tee /host/proc/sys/fs/binfmt_misc/register; done
-
       - name: "Checkout repo"
         uses: actions/checkout@v4
 

--- a/btop/justfile
+++ b/btop/justfile
@@ -4,7 +4,7 @@ btop
 rocm-smi
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/compsize/justfile
+++ b/compsize/justfile
@@ -1,7 +1,7 @@
 name := "compsize"
 packages := "compsize"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/cri-o-1.29/justfile
+++ b/cri-o-1.29/justfile
@@ -7,7 +7,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/cri-o-1.30/justfile
+++ b/cri-o-1.30/justfile
@@ -7,7 +7,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/cri-o-1.31/justfile
+++ b/cri-o-1.31/justfile
@@ -7,7 +7,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/cri-o-1.32/Containerfile
+++ b/cri-o-1.32/Containerfile
@@ -1,0 +1,8 @@
+FROM baseimage
+
+RUN dnf install -y \
+    --exclude cri-tools \
+    cri-o1.32 \
+    cri-tools1.32 \
+    && \
+    dnf clean all

--- a/cri-o-1.32/README.md
+++ b/cri-o-1.32/README.md
@@ -1,0 +1,6 @@
+# cri-o-1.32
+
+CRI-O and cri-tools packages only.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For Kubernetes and CRI-O in a single system extension, see `kubernetes-cri-o-<version>` ones.

--- a/cri-o-1.32/justfile
+++ b/cri-o-1.32/justfile
@@ -1,0 +1,15 @@
+name := "cri-o-1.32"
+packages := "
+cri-o1.32
+cri-tools1.32
+"
+exclude_packages := "
+cri-tools
+"
+base_images := "
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default

--- a/distrobox/justfile
+++ b/distrobox/justfile
@@ -1,7 +1,7 @@
 name := "distrobox"
 packages := "distrobox"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/erofs-utils/justfile
+++ b/erofs-utils/justfile
@@ -1,7 +1,7 @@
 name := "erofs-utils"
 packages := "erofs-utils"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/gdb/justfile
+++ b/gdb/justfile
@@ -1,7 +1,7 @@
 name := "gdb"
 packages := "gdb"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/git-tools/justfile
+++ b/git-tools/justfile
@@ -4,7 +4,7 @@ git-absorb
 git-delta
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/htop/justfile
+++ b/htop/justfile
@@ -1,7 +1,7 @@
 name := "htop"
 packages := "htop"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/incus/justfile
+++ b/incus/justfile
@@ -5,7 +5,7 @@ incus-client
 "
 copr_repos := "ganto/lxc4"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/iwd/justfile
+++ b/iwd/justfile
@@ -2,7 +2,7 @@ name := "iwd"
 packages := "iwd"
 files := "usr"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/just/justfile
+++ b/just/justfile
@@ -1,7 +1,7 @@
 name := "just"
 packages := "just"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/kubernetes-1.29/justfile
+++ b/kubernetes-1.29/justfile
@@ -10,7 +10,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.30/justfile
+++ b/kubernetes-1.30/justfile
@@ -10,7 +10,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.31/justfile
+++ b/kubernetes-1.31/justfile
@@ -10,7 +10,7 @@ exclude_packages := "
 cri-tools
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.32/Containerfile
+++ b/kubernetes-1.32/Containerfile
@@ -1,7 +1,6 @@
 FROM baseimage
 
 RUN dnf install -y \
-    --enablerepo="updates-testing" \
     --exclude cri-tools \
     cri-tools1.32 \
     kubernetes1.32 \

--- a/kubernetes-1.32/justfile
+++ b/kubernetes-1.32/justfile
@@ -13,7 +13,7 @@ cri-tools
 # https://bodhi.fedoraproject.org/updates/FEDORA-2024-bc020f9b2d
 enable_repos := "updates-testing"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/kubernetes-1.32/justfile
+++ b/kubernetes-1.32/justfile
@@ -9,9 +9,6 @@ kubernetes1.32-systemd
 exclude_packages := "
 cri-tools
 "
-# https://bodhi.fedoraproject.org/updates/FEDORA-2024-7865310e27
-# https://bodhi.fedoraproject.org/updates/FEDORA-2024-bc020f9b2d
-enable_repos := "updates-testing"
 base_images := "
 quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "

--- a/kubernetes-cri-o-1.32/Containerfile
+++ b/kubernetes-cri-o-1.32/Containerfile
@@ -1,0 +1,12 @@
+FROM baseimage
+
+RUN dnf install -y \
+    --exclude cri-tools \
+    cri-o1.32 \
+    cri-tools1.32 \
+    kubernetes1.32 \
+    kubernetes1.32-client \
+    kubernetes1.32-kubeadm \
+    kubernetes1.32-systemd \
+    && \
+    dnf clean all

--- a/kubernetes-cri-o-1.32/README.md
+++ b/kubernetes-cri-o-1.32/README.md
@@ -1,0 +1,6 @@
+# kubernetes-cri-o-1.32
+
+Kubernetes and CRI-O packages in a single system extension.
+
+For Kubernetes only, see the `kubernetes-<version>` ones.
+For cri-o only, see the `cri-o-<version>` ones.

--- a/kubernetes-cri-o-1.32/justfile
+++ b/kubernetes-cri-o-1.32/justfile
@@ -1,0 +1,19 @@
+name := "kubernetes-cri-o-1.32"
+packages := "
+cri-o1.32
+cri-tools1.32
+kubernetes1.32
+kubernetes1.32-client
+kubernetes1.32-kubeadm
+kubernetes1.32-systemd
+"
+exclude_packages := "
+cri-tools
+"
+base_images := "
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default

--- a/mpd/justfile
+++ b/mpd/justfile
@@ -7,7 +7,7 @@ packages := "
     ncmpcpp
 "
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/neovim/justfile
+++ b/neovim/justfile
@@ -5,7 +5,7 @@ tree-sitter-cli
 "
 dnf_weak_deps := "false"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/python/justfile
+++ b/python/justfile
@@ -1,7 +1,7 @@
 name := "python"
 packages := "python3"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/ripgrep/justfile
+++ b/ripgrep/justfile
@@ -1,7 +1,7 @@
 name := "ripgrep"
 packages := "ripgrep"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/semanage/justfile
+++ b/semanage/justfile
@@ -1,7 +1,7 @@
 name := "semanage"
 packages := "policycoreutils-python-utils"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 "
 
 import '../sysext.just'

--- a/strace/justfile
+++ b/strace/justfile
@@ -1,7 +1,7 @@
 name := "strace"
 packages := "strace"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/tree/justfile
+++ b/tree/justfile
@@ -1,7 +1,7 @@
 name := "tree"
 packages := "tree"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/update_workflows.sh
+++ b/update_workflows.sh
@@ -103,6 +103,11 @@ main() {
     cat "${tmpl}/sysexts_footer"
     } > ".github/workflows/sysexts-${shortname}-${release}-${arch}.yml"
 
+    # Fix GitHub runner for aarch64
+    if [[ "${arch}" == "aarch64" ]]; then
+        sed -i "s/ubuntu-24.04/ubuntu-24.04-arm/" ".github/workflows/sysexts-${shortname}-${release}-${arch}.yml"
+    fi
+
     # Generate container sysexts workflows
     # Skip non x86-64 builds for now
     if [[ "${arch}" != "x86_64" ]]; then

--- a/vim/justfile
+++ b/vim/justfile
@@ -1,7 +1,7 @@
 name := "vim"
 packages := "vim"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "

--- a/zsh/justfile
+++ b/zsh/justfile
@@ -1,7 +1,7 @@
 name := "zsh"
 packages := "zsh"
 base_images := "
-quay.io/fedora/fedora-coreos:stable
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 quay.io/fedora-ostree-desktops/silverblue:41
 quay.io/fedora-ostree-desktops/kinoite:41
 "


### PR DESCRIPTION
workflow-templates/sysexts_footer: Only mark FCOS release as latest

We need to pick one as latest release, so let's always pick the Fedora
CoreOS one.

---

workflow-templates/sysexts_footer: Fixup sysupdate config for FCOS

Fixup the config to use `stable` instead of the Fedora release version
and append the arch for aarch64 until we improve our workflow to publish
a single release for both x86_64 and aarch64.

Fixes: https://github.com/travier/fedora-sysexts/issues/61

---

workflows: Update to use GitHub runners for aarch64

---

aarch64: Enable more sysexts for FCOS

---

kubernetes-1.32: Packages are now in stable repos

---

sysexts: Add cri-o-1.32 & kubernetes-cri-o-1.32