### PR TITLE
openssl: Initial sysext

### DIFF
--- a/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
@@ -498,6 +498,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: openssl"
+        env:
+          SYSEXT: openssl
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: ripgrep"
         env:
           SYSEXT: ripgrep

--- a/.github/workflows/sysexts-fedora-silverblue-42-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-42-x86_64.yml
@@ -468,6 +468,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: openssl"
+        env:
+          SYSEXT: openssl
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: ripgrep"
         env:
           SYSEXT: ripgrep

--- a/openssl/Containerfile
+++ b/openssl/Containerfile
@@ -1,0 +1,6 @@
+FROM baseimage
+
+RUN dnf install -y \
+    openssl \
+    && \
+    dnf clean all

--- a/openssl/README.md
+++ b/openssl/README.md
@@ -1,0 +1,5 @@
+# openssl
+
+Needed for the GSconnect shell extension on Silverblue
+
+See: https://github.com/fedora-silverblue/issue-tracker/issues/201

--- a/openssl/justfile
+++ b/openssl/justfile
@@ -1,0 +1,10 @@
+name := "openssl"
+packages := "openssl"
+base_images := "
+quay.io/fedora-ostree-desktops/silverblue:41
+quay.io/fedora-ostree-desktops/silverblue:42
+"
+
+import '../sysext.just'
+
+all: default


### PR DESCRIPTION
Needed for the GSconnect shell extension on Silverblue.

See: https://github.com/fedora-silverblue/issue-tracker/issues/201