### PR TITLE
feat: add mpd container build

### DIFF
--- a/mpd/Containerfile
+++ b/mpd/Containerfile
@@ -1,0 +1,13 @@
+FROM baseimage
+
+RUN dnf install -y \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
+    && \
+    dnf install -y \
+    mpd \
+    mpc \
+    mpdris2 \
+    ncmpcpp \
+    && \
+    dnf clean all


### PR DESCRIPTION
adds mpd container build without push and sign
see https://github.com/travier/fedora-sysexts/pull/68

mpdris2 is the component that doesn't work with the host in distrobox/quadlet
related: https://github.com/travier/fedora-sysexts/issues/44