### PR TITLE
feat: Add Bitwarden sysext

### DIFF
--- a/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-41-x86_64.yml
@@ -93,6 +93,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: bitwarden"
+        env:
+          SYSEXT: bitwarden
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: btop"
         env:
           SYSEXT: btop

--- a/.github/workflows/sysexts-fedora-kinoite-42-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-kinoite-42-x86_64.yml
@@ -93,6 +93,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: bitwarden"
+        env:
+          SYSEXT: bitwarden
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: btop"
         env:
           SYSEXT: btop

--- a/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-41-x86_64.yml
@@ -93,6 +93,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: bitwarden"
+        env:
+          SYSEXT: bitwarden
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: btop"
         env:
           SYSEXT: btop

--- a/.github/workflows/sysexts-fedora-silverblue-42-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-silverblue-42-x86_64.yml
@@ -93,6 +93,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: bitwarden"
+        env:
+          SYSEXT: bitwarden
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: btop"
         env:
           SYSEXT: btop

--- a/1password-gui/Containerfile
+++ b/1password-gui/Containerfile
@@ -19,7 +19,7 @@ RUN mv /opt{,.bak} \
     && \
     sed -i 's|^Exec=/opt/1Password|Exec=/usr/bin|g' /usr/share/applications/1password.desktop \
     && \
-    rmdir opt \
+    rmdir /opt \
     && \
     mv /opt{.bak,} \
     && \

--- a/bitwarden/Containerfile
+++ b/bitwarden/Containerfile
@@ -1,0 +1,24 @@
+FROM baseimage
+
+RUN mv /opt{,.bak} \
+    && \
+    mkdir /opt \
+    && \
+    && dnf install -y \
+    "https://bitwarden.com/download/?app=desktop&platform=linux&variant=rpm" \
+    && \
+    mv /opt/Bitwarden /usr/lib/Bitwarden \
+    && \
+    ln -sf /usr/lib/Bitwarden/bitwarden /usr/bin/bitwarden \
+    && \
+    ln -sf /usr/lib/Bitwarden/bitwarden-app /usr/bin/bitwarden-app \
+    && \
+    chmod 4755 /usr/lib/Bitwarden/chrome-sandbox \
+    && \
+    sed -i 's|^Exec=/opt/Bitwarden|Exec=/usr/bin|g' /usr/share/applications/bitwarden.desktop \
+    && \
+    rmdir /opt \
+    && \
+    mv /opt{.bak,} \
+    && \
+    dnf clean all

--- a/bitwarden/Justfile
+++ b/bitwarden/Justfile
@@ -1,0 +1,43 @@
+name := "bitwarden"
+packages := "bitwarden"
+pre_commands := "rm -rf /opt; mkdir /opt"
+base_images := "
+quay.io/fedora-ostree-desktops/silverblue:41
+quay.io/fedora-ostree-desktops/silverblue:42
+quay.io/fedora-ostree-desktops/kinoite:41
+quay.io/fedora-ostree-desktops/kinoite:42
+"
+
+import '../sysext.just'
+
+all: default
+
+download-manual arch=arch:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    mkdir -p rpms
+    curl -Lo rpms/bitwarden.rpm \
+        "https://bitwarden.com/download/?app=desktop&platform=linux&variant=rpm"
+
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
+    cd rootfs
+
+    ${SUDO} mv opt/Bitwarden usr/lib/Bitwarden
+    ${SUDO} rmdir opt
+    ${SUDO} mkdir usr/bin
+    ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden usr/bin/bitwarden
+    ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden-app /usr/bin/bitwarden-app
+    ${SUDO} chmod 4755 usr/lib/Bitwarden/chrome-sandbox
+    ${SUDO} sed -i 's|^Exec=/opt/Bitwarden|Exec=/usr/bin|g' usr/share/applications/bitwarden.desktop

--- a/bitwarden/README.md
+++ b/bitwarden/README.md
@@ -1,0 +1,10 @@
+# Bitwarden
+
+The [Bitwarden](https://bitwarden.com/) password manager.
+
+### Differences from the Flatpak version
+
+While both the packaged version and the Flatpak version are equal in core
+functionality, some features (e.g.: biometrics autosetup and the ssh-agent sock
+present at `$HOME/.bitwarden-ssh-agent.sock` ) are still only available in the
+non-sandboxed version of the app.

--- a/mullvad-vpn/Containerfile
+++ b/mullvad-vpn/Containerfile
@@ -18,7 +18,7 @@ RUN mv /opt{,.bak} \
     && \
     sed -i 's|^Exec=/opt/Mullvad VPN|Exec=/usr/bin|g' /usr/share/applications/mullvad-vpn.desktop \
     && \
-    rmdir opt \
+    rmdir /opt \
     && \
     mv /opt{.bak,} \
     && \


### PR DESCRIPTION
This PR adds the official [Bitwarden](https://bitwarden.com/) app. The installation is remarkably similar to 1Password.

While Bitwarden maintains an official flatpak package on Flathub, some features are only available with the packaged application.