### PR TITLE
kubernetes*: Collection of small fixes

### DIFF
--- a/kubernetes-1.29/justfile
+++ b/kubernetes-1.29/justfile
@@ -4,7 +4,6 @@ cri-tools1.29
 kubernetes1.29
 kubernetes1.29-client
 kubernetes1.29-kubeadm
-kubernetes1.29-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-1.29/justfile
+++ b/kubernetes-1.29/justfile
@@ -15,3 +15,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-1.30/justfile
+++ b/kubernetes-1.30/justfile
@@ -4,7 +4,6 @@ cri-tools1.30
 kubernetes1.30
 kubernetes1.30-client
 kubernetes1.30-kubeadm
-kubernetes1.30-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-1.30/justfile
+++ b/kubernetes-1.30/justfile
@@ -15,3 +15,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-1.31/justfile
+++ b/kubernetes-1.31/justfile
@@ -4,7 +4,6 @@ cri-tools1.31
 kubernetes1.31
 kubernetes1.31-client
 kubernetes1.31-kubeadm
-kubernetes1.31-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-1.31/justfile
+++ b/kubernetes-1.31/justfile
@@ -15,3 +15,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-1.32/justfile
+++ b/kubernetes-1.32/justfile
@@ -4,7 +4,6 @@ cri-tools1.32
 kubernetes1.32
 kubernetes1.32-client
 kubernetes1.32-kubeadm
-kubernetes1.32-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-1.32/justfile
+++ b/kubernetes-1.32/justfile
@@ -15,3 +15,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -16,3 +16,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -5,7 +5,6 @@ cri-tools1.29
 kubernetes1.29
 kubernetes1.29-client
 kubernetes1.29-kubeadm
-kubernetes1.29-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -16,3 +16,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -5,7 +5,6 @@ cri-tools1.30
 kubernetes1.30
 kubernetes1.30-client
 kubernetes1.30-kubeadm
-kubernetes1.30-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -16,3 +16,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -5,7 +5,6 @@ cri-tools1.31
 kubernetes1.31
 kubernetes1.31-client
 kubernetes1.31-kubeadm
-kubernetes1.31-systemd
 "
 exclude_packages := "
 cri-tools

--- a/kubernetes-cri-o-1.32/justfile
+++ b/kubernetes-cri-o-1.32/justfile
@@ -16,3 +16,16 @@ quay.io/fedora/fedora-coreos:stable x86_64,aarch64
 import '../sysext.just'
 
 all: default
+
+# Setup folder that is expected by Kubernetes
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+    cd rootfs
+    ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec

--- a/kubernetes-cri-o-1.32/justfile
+++ b/kubernetes-cri-o-1.32/justfile
@@ -5,7 +5,6 @@ cri-tools1.32
 kubernetes1.32
 kubernetes1.32-client
 kubernetes1.32-kubeadm
-kubernetes1.32-systemd
 "
 exclude_packages := "
 cri-tools


### PR DESCRIPTION
kubernetes*: Remove kubernetes-systemd subpackage

This is not needed when setting up the cluster with kubeadm, i.e. hosted
control plane.

---

kubernetes*: Setup kubelet-plugins/volume/exec folder

kubelet expects this folder to exists and looks at it to find
additional third party volume plugins.

Those plugins could be added to this folder via another sysext for
example.

See: https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/
See: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/