### PR TITLE
fix: replace all spaces in shortname

### DIFF
--- a/update_workflows.sh
+++ b/update_workflows.sh
@@ -72,7 +72,7 @@ generate() {
     local -r release="${2}"
     local -r arch="${3}"
     local -r name="${4}"
-    local -r shortname="$(echo "${name}" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/')"
+    local -r shortname="$(echo "${name}" | tr '[:upper:]' '[:lower:]' | sed 's/ /-/g')"
 
     # For containers only
     local -r registry="quay.io/travier"


### PR DESCRIPTION
Currently, the generated shortname has only the first space replaced with a hyphen:

"Fedora Sway Atomic" becomes "fedora-sway atomic"

with this change:

"Fedora Sway Atomic" becomes "fedora-sway-atomic"

This'll save the annoyance of spaces in filenames particularly if/when you enable builds for the other atomic variants.