### PR TITLE
Add cilium-cli, youki & lock sysexts to matching ID/VERSION_ID

### DIFF
--- a/.github/workflows/sysexts-fedora-coreos-next-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-next-aarch64.yml
@@ -528,6 +528,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: youki"
+        env:
+          SYSEXT: youki
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: zsh"
         env:
           SYSEXT: zsh

--- a/.github/workflows/sysexts-fedora-coreos-next-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-next-aarch64.yml
@@ -78,6 +78,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: cilium-cli"
+        env:
+          SYSEXT: cilium-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: compsize"
         env:
           SYSEXT: compsize

--- a/.github/workflows/sysexts-fedora-coreos-next-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-next-x86_64.yml
@@ -588,6 +588,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: youki"
+        env:
+          SYSEXT: youki
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: zsh"
         env:
           SYSEXT: zsh

--- a/.github/workflows/sysexts-fedora-coreos-next-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-next-x86_64.yml
@@ -78,6 +78,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: cilium-cli"
+        env:
+          SYSEXT: cilium-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: cockpit"
         env:
           SYSEXT: cockpit

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -528,6 +528,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: youki"
+        env:
+          SYSEXT: youki
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: zsh"
         env:
           SYSEXT: zsh

--- a/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-aarch64.yml
@@ -78,6 +78,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: cilium-cli"
+        env:
+          SYSEXT: cilium-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: compsize"
         env:
           SYSEXT: compsize

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -603,6 +603,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: youki"
+        env:
+          SYSEXT: youki
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: zsh"
         env:
           SYSEXT: zsh

--- a/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
+++ b/.github/workflows/sysexts-fedora-coreos-stable-x86_64.yml
@@ -93,6 +93,21 @@ jobs:
           just build ${IMAGE} ${ARCH}
           mv "${SYSEXT}"*".raw" "../artifacts/"
 
+      - name: "Build sysext: cilium-cli"
+        env:
+          SYSEXT: cilium-cli
+        run: |
+          cd "${SYSEXT}"
+          if [[ "${PR}" == "true" ]]; then
+              diff="$(git diff origin/main HEAD --stat -- . ; git diff origin/main HEAD --stat -- ../sysext.just)"
+              if [[ -z "${diff}" ]]; then
+                  echo "Skipping: No changes for this sysext in this PR"
+                  exit 0
+              fi
+          fi
+          just build ${IMAGE} ${ARCH}
+          mv "${SYSEXT}"*".raw" "../artifacts/"
+
       - name: "Build sysext: cockpit"
         env:
           SYSEXT: cockpit

--- a/cilium-cli/justfile
+++ b/cilium-cli/justfile
@@ -1,0 +1,54 @@
+name := "cilium-cli"
+base_images := "
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
+quay.io/fedora/fedora-coreos:next x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default
+
+# Custom download step to get bandwhich
+download-manual arch=arch:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    mkdir binaries
+    cd binaries
+
+    echo "⬇️ Downloading cilium-cli"
+
+    VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
+
+    if [[ "{{arch}}" == "x86_64" ]]; then
+        ARCH=amd64
+    else
+        ARCH=arm64
+    fi
+
+    curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${VERSION}/cilium-linux-${ARCH}.tar.gz{,.sha256sum}
+    sha256sum --check cilium-linux-${ARCH}.tar.gz.sha256sum
+    tar xzvfC cilium-linux-${ARCH}.tar.gz ./
+
+    curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/raw/refs/tags/${VERSION}/LICENSE
+
+# Custom installation step to install bandwhich
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
+    cd rootfs
+
+    echo "➡️ Installing cilium-cli"
+    ${SUDO} install -D -m 755 ../binaries/cilium  usr/bin/cilium
+    ${SUDO} install -D -m 644 ../binaries/LICENSE usr/share/licenses/cilium/LICENSE
+
+    ${SUDO} chown -R root: usr

--- a/sysext.just
+++ b/sysext.just
@@ -64,7 +64,7 @@ build target arch=arch: \
     clean \
     (download-rpms target arch) \
     (download-manual arch) \
-    (setup-rootfs arch) \
+    (setup-rootfs target arch) \
     install-rpms \
     install-files \
     install-manual \
@@ -244,7 +244,7 @@ download-manual arch=arch:
     exit 0
 
 # Sets up the rootfs directory and creates the extension release config
-setup-rootfs arch=arch:
+setup-rootfs target arch=arch:
     #!/bin/bash
     set -euo pipefail
     # set -x
@@ -286,9 +286,15 @@ setup-rootfs arch=arch:
     fi
 
     echo "➡️ Setting up extension config file"
+    version_id=$(podman run --rm -ti \
+        --arch={{arch}} \
+        --security-opt label=disable \
+        "{{target}}" \
+        bash -c 'source /etc/os-release ; echo -n ${VERSION_ID}')
     ${SUDO} install -d -m0755 usr/lib/extension-release.d
     {
-    echo "ID=\"_any\""
+    echo "ID=\"fedora\""
+    echo "VERSION_ID=\"${version_id}\""
     # Post process architecture to match systemd architecture list
     arch="$(echo {{arch}} | sed 's/_/-/g')"
     echo "ARCHITECTURE=\"${arch}\""

--- a/youki/justfile
+++ b/youki/justfile
@@ -1,0 +1,52 @@
+name := "youki"
+base_images := "
+quay.io/fedora/fedora-coreos:stable x86_64,aarch64
+quay.io/fedora/fedora-coreos:next x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default
+
+# Custom download step to get bandwhich
+download-manual arch=arch:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    mkdir binaries
+    cd binaries
+
+    ARCH="{{arch}}"
+    VERSION="0.5.3" # TODO
+    if [[ "${ARCH}" == "x86_64" ]]; then
+        SHA256SUM="173b8998cd0abf22e38e36611b34cc19a16431b353dd893e3d988cfc77b4e6ac"
+    else
+        SHA256SUM="a15dfe9a1eec2d595b9a972a8a0fa1a919ee3d3523e77ca8c22099bfadf7e88d"
+    fi
+
+    echo "⬇️ Downloading youki"
+    curl -L --location --remote-name-all "https://github.com/youki-dev/youki/releases/download/v${VERSION}/youki-${VERSION}-${ARCH}-gnu.tar.gz"
+    echo "${SHA256SUM}  youki-${VERSION}-${ARCH}-gnu.tar.gz" | sha256sum --check
+    tar xf youki-${VERSION}-${ARCH}-gnu.tar.gz
+    rm youki-${VERSION}-${ARCH}-gnu.tar.gz README.md
+
+# Custom installation step to install bandwhich
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
+    cd rootfs
+
+    echo "➡️ Installing youki"
+    ${SUDO} install -D -m 755 ../binaries/youki   usr/bin/youki
+    ${SUDO} install -D -m 644 ../binaries/LICENSE usr/share/licenses/youki/LICENSE
+
+    ${SUDO} chown -R root: usr


### PR DESCRIPTION
sysext.just: Lock sysexts to matching ID/VERSION_ID

The sysexts built in this repos are built for Fedora and for specific
releases. Set the ID and VERSION_ID in the extension config file in
order to tell systemd-sysext to only use those sysexts on systems with
matching ID/VERSION_ID.

---

cilium-cli: Add initial sysext

---

youki: Add initial sysext