### PR TITLE
fix typo in bitwarden install-manual step

### DIFF
--- a/bitwarden/Justfile
+++ b/bitwarden/Justfile
@@ -38,6 +38,6 @@ install-manual:
     ${SUDO} rmdir opt
     ${SUDO} mkdir usr/bin
     ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden usr/bin/bitwarden
-    ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden-app /usr/bin/bitwarden-app
+    ${SUDO} ln -sf /usr/lib/Bitwarden/bitwarden-app usr/bin/bitwarden-app
     ${SUDO} chmod 4755 usr/lib/Bitwarden/chrome-sandbox
     ${SUDO} sed -i 's|^Exec=/opt/Bitwarden|Exec=/usr/bin|g' usr/share/applications/bitwarden.desktop


### PR DESCRIPTION
it is a short one. 

was also asking myself where I could add the command `sudo flatpak-spawn --host just build "quay.io/fedora/fedora-coreos:next"` ?  running just within a toolbox does not work for me and I found that command in another of your issues.