### PR TITLE
github/workflows: Always gather existing releases, even on failures

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -1647,9 +1647,8 @@ jobs:
       - build-fedora-coreos-stable-aarch64
       - build-fedora-coreos-next-x86_64
       - build-fedora-coreos-next-aarch64
-    # Still run if any dependent job fails
-    # if: ${{ always() }}
-    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    # Use `always()` to still run if any dependent job fails
+    if: ${{ always() && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4

--- a/.workflow-templates/20_sysexts_gather
+++ b/.workflow-templates/20_sysexts_gather
@@ -13,9 +13,8 @@
       - build-fedora-coreos-stable-aarch64
       - build-fedora-coreos-next-x86_64
       - build-fedora-coreos-next-aarch64
-    # Still run if any dependent job fails
-    # if: ${{ always() }}
-    if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    # Use `always()` to still run if any dependent job fails
+    if: ${{ always() && (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4


### PR DESCRIPTION
We always want to update the list of sysexts with the new ones, even if we failed building one.

This should also reduce the impact of:
https://github.com/travier/fedora-sysexts/issues/93