### PR TITLE
emacs: Add libvterm

### DIFF
--- a/emacs/justfile
+++ b/emacs/justfile
@@ -1,5 +1,8 @@
 name := "emacs"
-packages := "emacs libvterm"
+packages := "
+emacs
+libvterm
+"
 dnf_weak_deps := "false"
 base_images := "
 quay.io/fedora-ostree-desktops/base-atomic:41 x86_64,aarch64


### PR DESCRIPTION
libvterm does not get pulled in as a dependency. It is required for the popular vterm package which is usually the recommend terminal emulator inside of emacs.

Neovim pulls in this dependency for it's built-in terminal emulator.