### PR TITLE
libvirtd-desktop: Ensure libosinfo is included & s/qemu/qemu-kvm

### DIFF
--- a/libvirtd-desktop/justfile
+++ b/libvirtd-desktop/justfile
@@ -16,7 +16,7 @@ libvirt-daemon-driver-secret
 libvirt-daemon-driver-storage-core
 libvirt-dbus
 netcat
-qemu
+qemu-kvm
 qemu-img
 swtpm
 virt-install


### PR DESCRIPTION
libvirtd-desktop: Ensure libosinfo is included

This should be pulled as a dependency but for some reason it's not.
Let's manually include it for now.

Fixes: https://github.com/travier/fedora-sysexts/issues/116

---

libvirtd-desktop: Use qemu-kvm instead of qemu

Only install the qemu-system package that matches the system
architecture.

Fixes: https://github.com/travier/fedora-sysexts/issues/117