### PR TITLE
sysext.just: Fix arch names to match what systemd expects

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -58,7 +58,14 @@ runs:
 
         VERSION_ID="$(cat ./version_id)"
         VERSION="$(cat ./version)"
-        ARCH="$(uname -m | sed 's/_/-/g')"
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+            ARCH="x86-64"
+        elif [[ "$(uname -m)" == "aarch64" ]]; then
+            ARCH="arm64"
+        else
+            echo "Unsupported architecture"
+            exit 1
+        fi
         TAGNAME="${SYSEXT}-${VERSION}-${VERSION_ID}-${ARCH}"
 
         echo "Fetching info from existing release: ${TAGNAME}"
@@ -88,7 +95,14 @@ runs:
 
         VERSION="$(cat ./version)"
         VERSION_ID="$(cat ./version_id)"
-        ARCH="$(uname -m | sed 's/_/-/g')"
+        if [[ "$(uname -m)" == "x86_64" ]]; then
+            ARCH="x86-64"
+        elif [[ "$(uname -m)" == "aarch64" ]]; then
+            ARCH="arm64"
+        else
+            echo "Unsupported architecture"
+            exit 1
+        fi
         TAGNAME="${SYSEXT}-${VERSION}-${VERSION_ID}-${ARCH}"
 
         if [[ ! -f "./${TAGNAME}.raw" ]]; then

--- a/gdb/justfile
+++ b/gdb/justfile
@@ -24,4 +24,3 @@ install-manual:
 
     # Empty out /var
     ${SUDO} rm var/lib/unbound/root.key
-    ${SUDO} rmdir var/lib/unbound var/lib var/cache/dnf var/cache var

--- a/incus/justfile
+++ b/incus/justfile
@@ -13,23 +13,3 @@ quay.io/fedora-ostree-desktops/base-atomic:42 x86_64,aarch64
 import '../sysext.just'
 
 all: default
-
-install-manual:
-    #!/bin/bash
-    set -euo pipefail
-    # set -x
-
-    if [[ "${UID}" == "0" ]]; then
-        SUDO=""
-    else
-        SUDO="sudo"
-    fi
-
-    cd rootfs
-
-    # Empty out /var
-    ${SUDO} rmdir \
-        var/cache/{incus,lxc} var/cache \
-        var/lib/{incus,lxc,lxcfs} var/lib \
-        var/log/incus var/log \
-        var

--- a/inxi/justfile
+++ b/inxi/justfile
@@ -24,9 +24,3 @@ install-manual:
 
     # Empty out /var
     ${SUDO} rm ./var/lib/freeipmi/ipckey
-    ${SUDO} rmdir \
-        ./var/cache/ipmimonitoringsdrcache \
-        ./var/cache \
-        ./var/lib/freeipmi \
-        ./var/lib \
-        ./var

--- a/iwd/justfile
+++ b/iwd/justfile
@@ -9,19 +9,3 @@ quay.io/fedora-ostree-desktops/base-atomic:42 x86_64,aarch64
 import '../sysext.just'
 
 all: default
-
-install-manual:
-    #!/bin/bash
-    set -euo pipefail
-    # set -x
-
-    if [[ "${UID}" == "0" ]]; then
-        SUDO=""
-    else
-        SUDO="sudo"
-    fi
-
-    cd rootfs
-
-    # Empty out /var
-    ${SUDO} rmdir var/lib/{ead,iwd} var/lib var

--- a/kubernetes-1.29/justfile
+++ b/kubernetes-1.29/justfile
@@ -36,6 +36,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-1.30/justfile
+++ b/kubernetes-1.30/justfile
@@ -36,6 +36,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-1.31/justfile
+++ b/kubernetes-1.31/justfile
@@ -36,6 +36,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-1.32/justfile
+++ b/kubernetes-1.32/justfile
@@ -36,6 +36,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-1.33/justfile
+++ b/kubernetes-1.33/justfile
@@ -36,6 +36,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-cri-o-1.29/justfile
+++ b/kubernetes-cri-o-1.29/justfile
@@ -38,7 +38,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/containers
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-cri-o-1.30/justfile
+++ b/kubernetes-cri-o-1.30/justfile
@@ -38,7 +38,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/containers
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-cri-o-1.31/justfile
+++ b/kubernetes-cri-o-1.31/justfile
@@ -38,7 +38,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/containers
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-cri-o-1.32/justfile
+++ b/kubernetes-cri-o-1.32/justfile
@@ -38,7 +38,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/containers
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/kubernetes-cri-o-1.33/justfile
+++ b/kubernetes-cri-o-1.33/justfile
@@ -41,7 +41,3 @@ install-manual:
 
     # Setup folder that is expected by Kubernetes
     ${SUDO} install -d -m 755 -o 0 -g 0 usr/libexec/kubernetes/kubelet-plugins/volume/exec
-
-    # Ignore folder in /var
-    ${SUDO} rmdir var/lib/containers
-    ${SUDO} rmdir var/lib/kubelet var/lib var

--- a/nordvpn-gui/justfile
+++ b/nordvpn-gui/justfile
@@ -30,7 +30,6 @@ install-manual:
 
     # Move /var content
     ${SUDO} mv var/lib/nordvpn usr/share
-    ${SUDO} rmdir var/lib var
     # Fix permission for tmpfiles config
     ${SUDO} chmod 644 usr/lib/tmpfiles.d/nordvpn.conf
     # Remove service mask
@@ -44,5 +43,4 @@ install-manual:
 
     # Move nordvpn-gui to /usr
     ${SUDO} mv opt/nordvpn-gui usr/lib/nordvpn-gui
-    ${SUDO} rmdir opt
     ${SUDO} ln -sf /usr/lib/nordvpn-gui/nordvpn-gui usr/bin/nordvpn-gui

--- a/nordvpn/justfile
+++ b/nordvpn/justfile
@@ -30,7 +30,6 @@ install-manual:
 
     # Move /var content
     ${SUDO} mv var/lib/nordvpn usr/share
-    ${SUDO} rmdir var/lib var
     # Fix permission for tmpfiles config
     ${SUDO} chmod 644 usr/lib/tmpfiles.d/nordvpn.conf
     # Remove service mask

--- a/semanage/justfile
+++ b/semanage/justfile
@@ -8,25 +8,3 @@ quay.io/fedora/fedora-coreos:next x86_64,aarch64
 import '../sysext.just'
 
 all: default
-
-install-manual:
-    #!/bin/bash
-    set -euo pipefail
-    # set -x
-
-    if [[ "${UID}" == "0" ]]; then
-        SUDO=""
-    else
-        SUDO="sudo"
-    fi
-
-    cd rootfs
-
-    # Empty out /var
-    ${SUDO} rmdir \
-        ./var/lib/selinux/tmp \
-        ./var/lib/selinux \
-        ./var/lib \
-        ./var \
-        ./run/setrans \
-        ./run

--- a/steam-kinoite/justfile
+++ b/steam-kinoite/justfile
@@ -32,6 +32,3 @@ install-manual:
     # Merge /lib with /usr/lib
     ${SUDO} mv ./lib/* ./usr/lib
     ${SUDO} rmdir ./lib
-
-    # Empty out /var & /run
-    ${SUDO} rm -rf ./var ./run

--- a/steam-silverblue/justfile
+++ b/steam-silverblue/justfile
@@ -32,6 +32,3 @@ install-manual:
     # Merge /lib with /usr/lib
     ${SUDO} mv ./lib/* ./usr/lib
     ${SUDO} rmdir ./lib
-
-    # Empty out /var & /run
-    ${SUDO} rm -rf ./var ./run

--- a/sysext.just
+++ b/sysext.just
@@ -454,7 +454,14 @@ setup-rootfs target arch=arch:
     fi
 
     # Post process architecture to match systemd architecture list
-    arch="$(echo {{arch}} | sed 's/_/-/g')"
+    if [[ {{arch}} == "x86_64" ]]; then
+        arch="x86-64"
+    elif [[ {{arch}} == "aarch64" ]]; then
+        arch="arm64"
+    else
+        echo "Unsupported architecture"
+        exit 1
+    fi
 
     echo "➡️ Setting up extension config file"
     ${SUDO} install -d -m0755 usr/lib/extension-release.d
@@ -688,7 +695,14 @@ build-erofs target arch=arch:
     version="$(cat ./version)"
     version_id="$(cat ./version_id)"
     # Post process architecture to match systemd architecture list
-    arch="$(echo {{arch}} | sed 's/_/-/g')"
+    if [[ {{arch}} == "x86_64" ]]; then
+        arch="x86-64"
+    elif [[ {{arch}} == "aarch64" ]]; then
+        arch="arm64"
+    else
+        echo "Unsupported architecture"
+        exit 1
+    fi
 
     echo "🔒 Creating EROFS sysext ({{compression}})"
     ${SUDO} mkfs.erofs -z{{compression}} {{name}}-${version}-${version_id}-${arch}.raw rootfs > /dev/null

--- a/sysext.just
+++ b/sysext.just
@@ -568,7 +568,21 @@ validate:
 
     failed_checks=0
 
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
     cd rootfs
+
+    # First, we remove all empty directories in /var, /run and /opt
+    for d in 'var' 'run' 'opt'; do
+        if [[ -d "./${d}" ]]; then
+            echo "🧹 Cleaning up empty directories in /${d}"
+            ${SUDO} find "./${d}" -type d -empty -delete
+        fi
+    done
 
     # Check sbin/bin merge starting with Fedora 42
     if [[ "${version_id}" -ge 42 ]] && [[ -d "usr/sbin" ]]; then

--- a/sysext.just
+++ b/sysext.just
@@ -57,6 +57,9 @@ compression := "lz4"
 # Defaut to false.
 debug := env('JUST_DEBUG', '')
 
+# Default podman options
+podman_opts := "--rm --arch=" + arch + " --security-opt label=disable"
+
 # Default, empty, just recipe
 default:
     #!/bin/bash
@@ -259,10 +262,7 @@ download-rpms target arch=arch:
     fi
 
     if [[ -n "{{rpm_fusion_repos}}" ]]; then
-        release=$(podman run --rm \
-            --arch={{arch}} \
-            --security-opt label=disable \
-            "{{target}}" \
+        release=$(podman run {{podman_opts}} "{{target}}" \
             bash -c 'rpm -E %fedora' | tr -d '\n')
         for r in {{rpm_fusion_repos}}; do
             if [[ "${r}" != "free" ]] && [[ "${r}" != "nonfree" ]]; then
@@ -281,12 +281,10 @@ download-rpms target arch=arch:
 
     echo "⬇️ Downloading packages (${dnf_arches}): ${packages}"
     # dnf install --downloadonly --downloaddir . ${dnf_arch} ${enablerepos} ${packages}
-    podman run --rm -ti \
-        --arch={{arch}} \
+    podman run -ti {{podman_opts}} \
         --volume "${PWD}:/var/srv" \
         --volume "${PWD}/../../.dnf-cache:/var/cache/libdnf5" \
         --workdir "/var/srv" \
-        --security-opt label=disable \
         "{{target}}" \
         bash -xc "export FORCE_COLUMNS=100 && ${pre_commands}dnf download --resolve ${dnf_arch} ${dnf_opts} ${disablerepos} ${enablerepos} ${packages}"
 
@@ -365,10 +363,7 @@ inputs target arch=arch:
     if [[ -f ./version ]]; then
         version="$(cat ./version)"
     else
-        version=$(podman run --rm \
-            --arch={{arch}} \
-            --security-opt label=disable \
-            "{{target}}" \
+        version=$(podman run {{podman_opts}} "{{target}}" \
             bash -c 'source /etc/os-release ; echo -n ${OSTREE_VERSION}')
     fi
     # Remove special characters from the version
@@ -380,10 +375,7 @@ inputs target arch=arch:
     echo "{{target}}@$(podman inspect {{target}} | jq -r '.[0].Digest')" > ./digest
 
     # Store version_id (Fedora release)
-    version_id=$(podman run --rm \
-        --arch={{arch}} \
-        --security-opt label=disable \
-        "{{target}}" \
+    version_id=$(podman run {{podman_opts}} "{{target}}" \
         bash -c 'source /etc/os-release ; echo -n ${VERSION_ID}')
     echo "${version_id}" > ./version_id
 
@@ -668,12 +660,10 @@ reset-selinux-labels target arch=arch:
 
     filecontexts="/etc/selinux/targeted/contexts/files/file_contexts"
     echo "🏷️ Resetting SELinux labels"
-    podman run --rm -ti \
-        --arch={{arch}} \
+    podman run -ti {{podman_opts}} \
         --volume "${PWD}:/var/srv" \
         --volume "${PWD}/../.dnf-cache:/var/cache/libdnf5" \
         --workdir "/var/srv" \
-        --security-opt label=disable \
         --privileged \
         "{{target}}" \
         bash -c "${pre_commands}cd rootfs && setfiles -r . ${filecontexts} . && chcon --user=system_u --recursive ."

--- a/tailscale/justfile
+++ b/tailscale/justfile
@@ -30,9 +30,6 @@ install-manual:
 
     cd rootfs
 
-    # Remove /var
-    ${SUDO} rmdir var/cache/tailscale var/cache var
-
     # Move service from /lib to /usr/lib
     ${SUDO} mv lib/systemd/system/tailscaled.service usr/lib/systemd/system/
     ${SUDO} rmdir lib/systemd/system lib/systemd lib


### PR DESCRIPTION
sysext.just: Fix arch names to match what systemd expects

See: https://www.freedesktop.org/software/systemd/man/latest/sysupdate.d.html#Specifiers
See: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#ConditionArchitecture=

Fixes: https://github.com/travier/fedora-sysexts/issues/125

---

sysext.just: Centralize podman options

---

sysext.just: Ignore empty directories in /var /run /opt

There isn't much value in erroring out on empty directories in /var,
/run or /opt as it is common for RPMs to include those files, even if
they use tmpfiles.d configs. Let's clear them by default to simplify
justfiles and reduce the amount of errors in CI on updates.

---

*: Remove all manual /var, /opt & /run cleanupSee: https://www.freedesktop.org/software/systemd/man/latest/sysupdate.d.html#Specifiers
See: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#ConditionArchitecture=