### PR TITLE
libvirtd-desktop: Explicitly include osinfo-db & osinfo-db-tools

### DIFF
--- a/libvirtd-desktop/justfile
+++ b/libvirtd-desktop/justfile
@@ -15,6 +15,8 @@ libvirt-daemon-driver-qemu
 libvirt-daemon-driver-secret
 libvirt-daemon-driver-storage-core
 libvirt-dbus
+osinfo-db
+osinfo-db-tools
 netcat
 qemu-kvm
 qemu-img


### PR DESCRIPTION
This should be pulled as a dependency but for some reason it's not. Let's manually include it for now.

See: https://github.com/travier/fedora-sysexts/issues/116
Fixes: https://github.com/travier/fedora-sysexts/issues/129