### PR TITLE
Add GitLab's GLab CLI Tool.

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -179,6 +179,12 @@ jobs:
           sysext: 'git-lfs'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: glab"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'glab'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: google-chrome"
         uses: ./.github/actions/build
         with:
@@ -546,6 +552,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'git-lfs'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: glab"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'glab'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: google-chrome"
@@ -1211,6 +1223,12 @@ jobs:
           sysext: 'git-lfs'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: glab"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'glab'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: helix"
         uses: ./.github/actions/build
         with:
@@ -1530,6 +1548,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'git-lfs'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: glab"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'glab'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: helix"
@@ -2085,4 +2109,4 @@ jobs:
       - name: "Gather all sysexts releases"
         uses: ./.github/actions/gather
         with:
-          sysexts: '1password-cli;1password-gui;adobe-source-code-pro-fonts;bandwhich;bitwarden;btop;bwm-ng;chromium;cilium-cli;cloud-hypervisor;distrobox;docker-ce;emacs;erofs-utils;fd-find;firefox;fish;fuse2;gdb;git-absorb;git-delta;git-lfs;google-chrome;helix;htop;igt-gpu-tools;incus;inxi;iotop;iwd;just;keepassxc;krb5-workstation;kubernetes-1.29;kubernetes-1.30;kubernetes-1.31;kubernetes-1.32;kubernetes-1.33;kubernetes-cri-o-1.29;kubernetes-cri-o-1.30;kubernetes-cri-o-1.31;kubernetes-cri-o-1.32;kubernetes-cri-o-1.33;libratbag;libvirtd;libvirtd-desktop;microsoft-edge;moby-engine;mullvad-vpn;neovim;nordvpn;nordvpn-gui;openh264;openssl;python3;ripgrep;semanage;source-foundry-hack-fonts;steam-devices;strace;tailscale;tmux;tree;vim;virtctl;vscode;vscodium;wasmtime;wireguard-tools;wireshark-kinoite;wireshark-silverblue;youki;zoxide;zsh;'
+          sysexts: '1password-cli;1password-gui;adobe-source-code-pro-fonts;bandwhich;bitwarden;btop;bwm-ng;chromium;cilium-cli;cloud-hypervisor;distrobox;docker-ce;emacs;erofs-utils;fd-find;firefox;fish;fuse2;gdb;git-absorb;git-delta;git-lfs;glab;google-chrome;helix;htop;igt-gpu-tools;incus;inxi;iotop;iwd;just;keepassxc;krb5-workstation;kubernetes-1.29;kubernetes-1.30;kubernetes-1.31;kubernetes-1.32;kubernetes-1.33;kubernetes-cri-o-1.29;kubernetes-cri-o-1.30;kubernetes-cri-o-1.31;kubernetes-cri-o-1.32;kubernetes-cri-o-1.33;libratbag;libvirtd;libvirtd-desktop;microsoft-edge;moby-engine;mullvad-vpn;neovim;nordvpn;nordvpn-gui;openh264;openssl;python3;ripgrep;semanage;source-foundry-hack-fonts;steam-devices;strace;tailscale;tmux;tree;vim;virtctl;vscode;vscodium;wasmtime;wireguard-tools;wireshark-kinoite;wireshark-silverblue;youki;zoxide;zsh;'

--- a/glab/README.md
+++ b/glab/README.md
@@ -1,0 +1,8 @@
+# GitLab CLI
+
+Upstream binary releases: <https://gitlab.com/gitlab-org/cli>
+
+## Compatibility
+
+This sysext is compatible with all Fedora variants (CoreOS, Atomic Desktops,
+etc.).

--- a/glab/justfile
+++ b/glab/justfile
@@ -1,0 +1,35 @@
+name := "glab"
+packages := "glab"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:41 x86_64,aarch64
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default
+
+# Custom download step to get the rpm
+download-rpms target arch=arch:
+    #!/bin/bash
+    set -euo pipefail
+    # set -x
+
+    mkdir rpms
+    cd rpms
+
+    version=$(curl -s --location --fail https://gitlab.com/api/v4/projects/34675721/releases/permalink/latest | jq --raw-output '.tag_name' | sed 's/^v//')
+
+    echo "⬇️ Downloading glab v${version}"
+
+    if [[ "{{arch}}" == "x86_64" ]]; then
+        arch=amd64
+    else
+        arch=arm64
+    fi
+
+    curl -s --location --fail --output "glab_${version}_linux_${arch}.rpm" \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${version}/downloads/glab_${version}_linux_${arch}.rpm"
+    curl -s --location --fail \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${version}/downloads/checksums.txt" | \
+        grep "glab_${version}_linux_${arch}.rpm" >> glab_${version}_linux_${arch}.rpm.sha256sum


### PR DESCRIPTION
Installs the tarball release of the GLab tool from GitLab. I tried to use the rpm release version originally, but the file structure internal is `/bin/glab` and so wasn't overlaid with systemd-sysext.  