### PR TITLE
tailscale: fix override file

### DIFF
--- a/tailscale/justfile
+++ b/tailscale/justfile
@@ -28,9 +28,9 @@ install-manual:
         SUDO="sudo"
     fi
 
-    cd rootfs
+    VERSION_ID="$(cat version_id)"
 
-    VERSION_ID="$(source /etc/os-release ; echo -n ${VERSION_ID})"
+    cd rootfs
 
     if [[ "${VERSION_ID}" -eq 41 ]]; then
         # Move service from /lib to /usr/lib for F41

--- a/tailscale/usr/lib/systemd/system/tailscaled.service.d/50-sysext-default.conf
+++ b/tailscale/usr/lib/systemd/system/tailscaled.service.d/50-sysext-default.conf
@@ -1,4 +1,4 @@
 # Set defaults from /usr/etc/default/tailscaled
 [Service]
-EnvironmentFile=""
+EnvironmentFile=
 EnvironmentFile=/usr/etc/default/tailscaled


### PR DESCRIPTION
To clear entry, the value must be absent. Current file are warned like so, and systemd doesn't start unit due to `resources` error when I don't have the original file:

```text
systemd[1]: /usr/lib/systemd/system/tailscaled.service.d/50-sysext-default.conf:3: EnvironmentFile= path is not absolute, ignoring: ""
systemd[1]: tailscaled.service: Failed to load environment files: No such file or directory
systemd[1]: tailscaled.service: Failed to spawn 'start' task: No such file or directory
```