### PR TITLE
openconnect: Add initial sysext

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -299,6 +299,12 @@ jobs:
           sysext: 'nordvpn'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: openconnect"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'openconnect'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: openh264"
         uses: ./.github/actions/build
         with:
@@ -678,6 +684,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'nordvpn'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: openconnect"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'openconnect'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: openh264"
@@ -2121,4 +2133,4 @@ jobs:
       - name: "Gather all sysexts releases"
         uses: ./.github/actions/gather
         with:
-          sysexts: '1password-cli;1password-gui;adobe-source-code-pro-fonts;bandwhich;bitwarden;btop;bwm-ng;chromium;cilium-cli;cloud-hypervisor;distrobox;docker-ce;emacs;erofs-utils;fd-find;firefox;fish;fuse2;gdb;git-absorb;git-delta;git-lfs;glab;google-chrome;helix;htop;igt-gpu-tools;incus;inxi;iotop;iwd;just;keepassxc;krb5-workstation;kubernetes-1.29;kubernetes-1.30;kubernetes-1.31;kubernetes-1.32;kubernetes-1.33;kubernetes-cri-o-1.29;kubernetes-cri-o-1.30;kubernetes-cri-o-1.31;kubernetes-cri-o-1.32;kubernetes-cri-o-1.33;libratbag;libvirtd;libvirtd-desktop;microsoft-edge;moby-engine;mullvad-vpn;neovim;nordvpn;nordvpn-gui;openh264;openssl;python3;ripgrep;semanage;source-foundry-hack-fonts;steam-devices;strace;tailscale;tmux;tree;vagrant;vim;virtctl;vscode;vscodium;wasmtime;wireguard-tools;wireshark-kinoite;wireshark-silverblue;youki;zoxide;zsh;'
+          sysexts: '1password-cli;1password-gui;adobe-source-code-pro-fonts;bandwhich;bitwarden;btop;bwm-ng;chromium;cilium-cli;cloud-hypervisor;distrobox;docker-ce;emacs;erofs-utils;fd-find;firefox;fish;fuse2;gdb;git-absorb;git-delta;git-lfs;glab;google-chrome;helix;htop;igt-gpu-tools;incus;inxi;iotop;iwd;just;keepassxc;krb5-workstation;kubernetes-1.29;kubernetes-1.30;kubernetes-1.31;kubernetes-1.32;kubernetes-1.33;kubernetes-cri-o-1.29;kubernetes-cri-o-1.30;kubernetes-cri-o-1.31;kubernetes-cri-o-1.32;kubernetes-cri-o-1.33;libratbag;libvirtd;libvirtd-desktop;microsoft-edge;moby-engine;mullvad-vpn;neovim;nordvpn;nordvpn-gui;openconnect;openh264;openssl;python3;ripgrep;semanage;source-foundry-hack-fonts;steam-devices;strace;tailscale;tmux;tree;vagrant;vim;virtctl;vscode;vscodium;wasmtime;wireguard-tools;wireshark-kinoite;wireshark-silverblue;youki;zoxide;zsh;'

--- a/openconnect/README.md
+++ b/openconnect/README.md
@@ -1,0 +1,19 @@
+# openconnect
+
+The primary motivation for creating this extension is to address a critical bug
+in openconnect-9.12-7 (the version currently available in Fedora 42) that
+prevents successful connections to certain VPN configurations. This bug is
+tracked here:
+<https://gitlab.com/openconnect/openconnect/-/issues/659>
+
+This extension is intended as a temporary solution until the openconnect
+package is updated in the official Fedora repositories. The issue is also
+tracked in Red Hat Bugzilla here:
+<https://bugzilla.redhat.com/show_bug.cgi?id=2376504>
+
+It is built from a COPR:
+[dwmw2/openconnect](https://copr.fedorainfracloud.org/coprs/dwmw2/openconnect/).
+
+## Compatibility
+
+This sysext is compatible with Fedora Atomic Desktops.

--- a/openconnect/justfile
+++ b/openconnect/justfile
@@ -1,0 +1,34 @@
+name := "openconnect"
+packages := "openconnect"
+copr_repos := "dwmw2/openconnect"
+version_package := "openconnect"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:41 x86_64
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64
+"
+
+import '../sysext.just'
+
+all: default
+
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    if [[ -n "{{debug}}" ]]; then
+      set -x
+    fi
+
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
+    VERSION_ID="$(cat ./version_id)"
+
+    cd rootfs
+
+    # Replace sbin with bin for F42+
+    if [[ "${VERSION_ID}" -ge 42 ]]; then
+        ${SUDO} mv usr/sbin usr/bin
+    fi


### PR DESCRIPTION
The primary motivation for creating this extension is to address a critical bug in `openconnect-9.12-7` (the version currently available in Fedora 42) that prevents successful connections to certain VPN configurations. This bug is tracked here:
[https://gitlab.com/openconnect/openconnect/-/issues/659](https://gitlab.com/openconnect/openconnect/-/issues/659)