### PR TITLE
tailscale: Remove 'default' EnvironmentFile workaround

### DIFF
--- a/tailscale/justfile
+++ b/tailscale/justfile
@@ -3,7 +3,7 @@ packages := "tailscale"
 files := "usr"
 # TODO: Disabled as this interactively query for confirmation and can not be bypassed
 # external_repos := "https://pkgs.tailscale.com/stable/fedora/tailscale.repo"
-# TODO: Workaround belown but something weird is going on here
+# TODO: Workaround below but something weird is going on here
 pre_commands := "dnf config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo && sed -i 's/repo_gpgcheck=1/repo_gpgcheck=0/g' /etc/yum.repos.d/tailscale.repo"
 upholds := "
 tailscaled.service

--- a/tailscale/usr/lib/systemd/system/tailscaled.service.d/50-sysext-default.conf
+++ b/tailscale/usr/lib/systemd/system/tailscaled.service.d/50-sysext-default.conf
@@ -1,4 +1,0 @@
-# Set defaults from /usr/etc/default/tailscaled
-[Service]
-EnvironmentFile=
-EnvironmentFile=/usr/etc/default/tailscaled


### PR DESCRIPTION
Looks like the package is not including or using this file in the
systemd unit anymore.

Fixes: #146