### PR TITLE
nebula: Add initial sysext

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -287,6 +287,12 @@ jobs:
           sysext: 'mullvad-vpn'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: nebula"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'nebula'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: neovim"
         uses: ./.github/actions/build
         with:
@@ -678,6 +684,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'mullvad-vpn'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: nebula"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'nebula'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: neovim"
@@ -1355,6 +1367,12 @@ jobs:
           sysext: 'mullvad-vpn'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: nebula"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'nebula'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: neovim"
         uses: ./.github/actions/build
         with:
@@ -1686,6 +1704,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'mullvad-vpn'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: nebula"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'nebula'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: neovim"
@@ -2157,4 +2181,4 @@ jobs:
       - name: "Gather all sysexts releases"
         uses: ./.github/actions/gather
         with:
-          sysexts: '1password-cli;1password-gui;adobe-source-code-pro-fonts;bandwhich;bitwarden;btop;bwm-ng;chromium;cilium-cli;cloud-hypervisor;distrobox;docker-ce;emacs;erofs-utils;fd-find;firefox;fish;fuse2;gdb;gh;git-absorb;git-delta;git-lfs;glab;google-chrome;helix;htop;igt-gpu-tools;incus;inxi;iotop;iwd;just;keepassxc;krb5-workstation;kubernetes-1.29;kubernetes-1.30;kubernetes-1.31;kubernetes-1.32;kubernetes-1.33;kubernetes-cri-o-1.29;kubernetes-cri-o-1.30;kubernetes-cri-o-1.31;kubernetes-cri-o-1.32;kubernetes-cri-o-1.33;libratbag;libvirtd;libvirtd-desktop;microsoft-edge;moby-engine;mullvad-vpn;neovim;nordvpn;nordvpn-gui;openconnect;openh264;openssl;python3;ripgrep;semanage;source-foundry-hack-fonts;steam-devices;strace;tailscale;tmux;tree;vagrant;vim;virtctl;vscode;vscodium;wasmtime;wireguard-tools;wireshark-kinoite;wireshark-silverblue;youki;zoxide;zsh;'
+          sysexts: '1password-cli;1password-gui;adobe-source-code-pro-fonts;bandwhich;bitwarden;btop;bwm-ng;chromium;cilium-cli;cloud-hypervisor;distrobox;docker-ce;emacs;erofs-utils;fd-find;firefox;fish;fuse2;gdb;gh;git-absorb;git-delta;git-lfs;glab;google-chrome;helix;htop;igt-gpu-tools;incus;inxi;iotop;iwd;just;keepassxc;krb5-workstation;kubernetes-1.29;kubernetes-1.30;kubernetes-1.31;kubernetes-1.32;kubernetes-1.33;kubernetes-cri-o-1.29;kubernetes-cri-o-1.30;kubernetes-cri-o-1.31;kubernetes-cri-o-1.32;kubernetes-cri-o-1.33;libratbag;libvirtd;libvirtd-desktop;microsoft-edge;moby-engine;mullvad-vpn;nebula;neovim;nordvpn;nordvpn-gui;openconnect;openh264;openssl;python3;ripgrep;semanage;source-foundry-hack-fonts;steam-devices;strace;tailscale;tmux;tree;vagrant;vim;virtctl;vscode;vscodium;wasmtime;wireguard-tools;wireshark-kinoite;wireshark-silverblue;youki;zoxide;zsh;'

--- a/nebula/Containerfile
+++ b/nebula/Containerfile
@@ -1,0 +1,7 @@
+FROM baseimage
+
+RUN <<EORUN
+set -xeuo pipefail
+dnf install -y nebula
+dnf clean all
+EORUN

--- a/nebula/README.md
+++ b/nebula/README.md
@@ -1,0 +1,8 @@
+# nebula
+
+`nebula` is a scalable overlay networking tool with a focus on performance, simplicity and security.
+
+## Compatibility
+
+This sysext should be compatible with all Fedora variants (CoreOS, Atomic
+Desktops, etc.) but has only been tested on Atomic Desktops.

--- a/nebula/justfile
+++ b/nebula/justfile
@@ -1,0 +1,10 @@
+name := "nebula"
+packages := "nebula"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:41 x86_64,aarch64
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default


### PR DESCRIPTION
Nebula would be great to have as a sysext for both coreos and atomic desktop. Nebula is an overlay network comparable to something like tailscale, and thus runs best on the host directly.

If any modifications are needed just let me know. And thanks for the work on the sysexts 😄