### PR TITLE
docs: merge Installation and Merging sections

### DIFF
--- a/.github/docs-templates/body.md
+++ b/.github/docs-templates/body.md
@@ -36,18 +36,15 @@ Install the sysext:
 ```
 install_sysext %%SYSEXT%%
 ```
-</details>
 
-<details markdown="block">
-<summary>Merging</summary>
-Note that this will merge all installed sysexts unconditionally:
+Reboot your system or refresh the merged sysexts:
 
 ```
 sudo systemctl restart systemd-sysext.service
 systemd-sysext status
 ```
 
-You can also reboot the system.
+Note that this will merge all installed sysexts unconditionally.
 </details>
 
 <details markdown="block">


### PR DESCRIPTION
In order for newly installed sysext to show up, sysexts need to be refreshed. It would be useful to add this information to the docs