### PR TITLE
qutebrowser: Add initial sysext

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -347,6 +347,12 @@ jobs:
           sysext: 'openssl'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: qutebrowser"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'qutebrowser'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: ripgrep"
         uses: ./.github/actions/build
         with:
@@ -762,6 +768,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'openssl'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: qutebrowser"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'qutebrowser'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: ripgrep"

--- a/qutebrowser/Containerfile
+++ b/qutebrowser/Containerfile
@@ -1,0 +1,8 @@
+FROM baseimage
+
+RUN <<EORUN
+set -xeuo pipefail
+dnf copr enable ismaelpuerto/python-adblock
+dnf install -y qutebrowser python3-adblock
+dnf clean all
+EORUN

--- a/qutebrowser/README.md
+++ b/qutebrowser/README.md
@@ -1,0 +1,9 @@
+# qutebrowser
+
+Alternative to the Flatpak which has known limitations. This enables the
+rust-based adblocker from a COPR:
+[ismaelpuerto/python-adblock](https://copr.fedorainfracloud.org/coprs/ismaelpuerto/python-adblock)
+
+## Compatibility
+
+This sysext is compatible with Fedora Atomic Desktops.

--- a/qutebrowser/justfile
+++ b/qutebrowser/justfile
@@ -1,0 +1,14 @@
+name := "qutebrowser"
+packages := "
+qutebrowser
+python3-adblock
+"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:41 x86_64
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64
+"
+copr_repos := "ismaelpuerto/python-adblock"
+
+import '../sysext.just'
+
+all: default


### PR DESCRIPTION
I tried this as an alternative to https://github.com/travier/fedora-sysexts/pull/134 because of its adblocker. The COPR adblocker doesn't enable support for aarch64 though.