### PR TITLE
Add output to build for conditional publish

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -74,11 +74,13 @@ runs:
 
         if [[ "${new}" == "${old}" ]]; then
           echo "No changes in inputs since last release. Skipping."
+          echo "PUBLISH=0" >> "$GITHUB_ENV"
           exit 0
         fi
 
         echo "Detected changes. Building new sysext for: ${TAGNAME}"
         just resume-build ${IMAGE}
+        echo "PUBLISH=1" >> "$GITHUB_ENV"
 
     - name: "Publish sysext"
       env:
@@ -88,6 +90,11 @@ runs:
       shell: bash
       run: |
         set -euxo pipefail
+
+        if [ "${{ env.PUBLISH }}" == "0" ]; then
+            echo "No new release. Skipping Publish"
+            exit 0
+        fi
 
         git config --global --add safe.directory "${PWD}"
 


### PR DESCRIPTION
Issue #160 notes that a release occurs every day regardless of a new version release upstream. This adds an environment variable to the GITHUB_ENV file in the build step that can be referenced in the publish step to skip the publish if there was no change.

I do not currently have the ability to test this in my fork and I am more accustomed to Gitlab CI.