### PR TITLE
Add dnclient sysext

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -119,6 +119,12 @@ jobs:
           sysext: 'distrobox'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: dnclient"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'dnclient'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: docker-ce"
         uses: ./.github/actions/build
         with:
@@ -540,6 +546,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'distrobox'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: dnclient"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'dnclient'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: docker-ce"
@@ -1259,6 +1271,12 @@ jobs:
           sysext: 'distrobox'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: dnclient"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'dnclient'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: docker-ce"
         uses: ./.github/actions/build
         with:
@@ -1614,6 +1632,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'distrobox'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: dnclient"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'dnclient'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: docker-ce"

--- a/dnclient/README.md
+++ b/dnclient/README.md
@@ -1,0 +1,8 @@
+# Defined Networking dnclient
+
+Upstream binary releases: <https://www.defined.net/downloads/>
+
+## Compatibility
+
+This sysext is compatible with all Fedora variants (CoreOS, Atomic Desktops,
+etc.).

--- a/dnclient/justfile
+++ b/dnclient/justfile
@@ -1,0 +1,62 @@
+name := "dnclient"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:41 x86_64,aarch64
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64,aarch64
+"
+
+import '../sysext.just'
+
+all: default
+
+# Custom download step to get the binary
+download-manual arch=arch:
+    #!/bin/bash
+    set -euo pipefail
+    if [[ -n "{{debug}}" ]]; then
+      set -x
+    fi
+
+    mkdir binaries
+    cd binaries
+
+    version=$(curl -s --location --fail https://api.defined.net/v1/downloads | jq --raw-output '.data.versionInfo.latest.dnclient')
+
+    echo "⬇️ Downloading dnclient v${version}"
+
+    if [[ "{{arch}}" == "x86_64" ]]; then
+        arch=amd64
+    else
+        arch=arm64
+    fi
+
+    download_link=$(curl -s --location --fail https://api.defined.net/v1/downloads | jq --raw-output --arg latest_version ${version} --arg arch "linux-${arch}" '.data.dnclient.[$latest_version].[$arch]')
+    sha=$(curl -s --location "$download_link.sha256")
+    curl -s --location --fail --output "dnclient" "$download_link"
+
+    echo "$sha dnclient" | sha256sum --check
+    
+    echo "${version}" > ../version
+    sha256sum dnclient >> ../inputs
+
+version:
+    true
+
+install-manual:
+    #!/bin/bash
+    set -euo pipefail
+    if [[ -n "{{debug}}" ]]; then
+      set -x
+    fi
+
+    if [[ "${UID}" == "0" ]]; then
+        SUDO=""
+    else
+        SUDO="sudo"
+    fi
+
+    cd rootfs
+
+    echo "➡️ Installing dnclient"
+    ${SUDO} install -D -m 755 ../binaries/dnclient usr/bin/dnclient
+
+    ${SUDO} chown -R root: usr


### PR DESCRIPTION
Adds the dnclient from Defined Networking. 

`dnclient` is a wrapper around the Nebula OSS overlay VPN (also provided as sysext in this repo) for more advanced management of the overlay network.