### PR TITLE
sysext.just: Disable openh264 repo by default

### DIFF
--- a/sysext.just
+++ b/sysext.just
@@ -209,6 +209,9 @@ download-rpms target arch=arch:
         exit 0
     fi
 
+    # Always disable the openh264 repo by default
+    dnf5 config-manager setopt fedora-cisco-openh264.enabled=0
+
     enablerepos=""
     if [[ -n "{{enable_repos}}" ]]; then
         for r in {{enable_repos}}; do


### PR DESCRIPTION
Disable to the repo by default to make sure that we never install it in a sysext by mistake.