### PR TITLE
sysext.just: Fix openh264 repo & auto-fix for /lib64

### DIFF
--- a/sysext.just
+++ b/sysext.just
@@ -209,9 +209,6 @@ download-rpms target arch=arch:
         exit 0
     fi
 
-    # Always disable the openh264 repo by default
-    dnf5 config-manager setopt fedora-cisco-openh264.enabled=0
-
     enablerepos=""
     if [[ -n "{{enable_repos}}" ]]; then
         for r in {{enable_repos}}; do
@@ -252,7 +249,9 @@ download-rpms target arch=arch:
 
     packages="$(echo "{{packages}}" | xargs)"
 
-    pre_commands=""
+    # Always disable the openh264 repo by default
+    pre_commands="dnf5 config-manager setopt fedora-cisco-openh264.enabled=0; "
+
     if [[ -n "{{pre_commands}}" ]]; then
         pre_commands+="{{pre_commands}} ; "
     fi

--- a/sysext.just
+++ b/sysext.just
@@ -607,6 +607,16 @@ validate:
         fi
     done
 
+    # Try to merge /lib64 with /usr/lib64
+    if [[ -d "lib64" ]]; then
+        echo "➡️ Moving /lib64 to /usr/lib64"
+        if [[ ! -d "usr/lib64" ]]; then
+            install -dm 0755 ./usr/lib64
+        fi
+        ${SUDO} mv --verbose --no-clobber ./lib64/* ./usr/lib64
+        ${SUDO} rmdir lib64
+    fi
+
     # Try to merge /usr/sbin with /usr/bin for Fedora 42+
     if [[ "${version_id}" -ge 42 ]] && [[ -d "usr/sbin" ]]; then
         echo "➡️ Moving /usr/sbin to /usr/bin"


### PR DESCRIPTION
sysext.just: Fix openh264 repo disabling

Use a pre command instead to disable that in the container where we do
the dnf operations, not on the "host".

Fixes: 0d1cec9 sysext.just: Disable openh264 repo by default

---

sysext.just: Add auto-fix for /lib64 -> /usr/lib64

Some packages still install files in /lib64. Automatically try to move
them to /usr/lib64 instead of failing on those.