### PR TITLE
Move virtlogd override

### DIFF
--- a/libvirtd-desktop/Containerfile
+++ b/libvirtd-desktop/Containerfile
@@ -27,4 +27,4 @@ EORUN
 
 COPY files/usr/lib/tmpfiles.d/libvirt.conf /usr/lib/tmpfiles.d/libvirt.conf
 
-COPY files/etc/systemd/system/virtlogd.service.d/override.conf /etc/systemd/system/virtlogd.service.d/override.conf
+COPY files/usr/lib/systemd/system/virtlogd.service.d/override.conf /etc/systemd/system/virtlogd.service.d/override.conf

--- a/libvirtd-desktop/Containerfile
+++ b/libvirtd-desktop/Containerfile
@@ -24,3 +24,7 @@ dnf install -y \
     virt-install
 dnf clean all
 EORUN
+
+COPY files/usr/lib/tmpfiles.d/libvirt.conf /usr/lib/tmpfiles.d/libvirt.conf
+
+COPY files/etc/systemd/system/virtlogd.service.d/override.conf /etc/systemd/system/virtlogd.service.d/override.conf

--- a/libvirtd-desktop/files/etc/systemd/system/virtlogd.service.d/override.conf
+++ b/libvirtd-desktop/files/etc/systemd/system/virtlogd.service.d/override.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Cody Istre
+# SPDX-License-Identifier: MIT
+
 [Service]
 LogsDirectory=libvirt/qemu
 ReadWritePaths=/var/log/libvirt

--- a/libvirtd-desktop/files/etc/systemd/system/virtlogd.service.d/override.conf
+++ b/libvirtd-desktop/files/etc/systemd/system/virtlogd.service.d/override.conf
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2025 Cody Istre
-# SPDX-License-Identifier: MIT
-
-[Service]
-LogsDirectory=libvirt/qemu
-ReadWritePaths=/var/log/libvirt

--- a/libvirtd-desktop/files/etc/systemd/system/virtlogd.service.d/override.conf
+++ b/libvirtd-desktop/files/etc/systemd/system/virtlogd.service.d/override.conf
@@ -1,0 +1,3 @@
+[Service]
+LogsDirectory=libvirt/qemu
+ReadWritePaths=/var/log/libvirt

--- a/libvirtd-desktop/files/usr/lib/systemd/system/virtlogd.service/override.conf
+++ b/libvirtd-desktop/files/usr/lib/systemd/system/virtlogd.service/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ReadWritePaths=/var/log/libvirt

--- a/libvirtd-desktop/files/usr/lib/tmpfiles.d/libvirt.conf
+++ b/libvirtd-desktop/files/usr/lib/tmpfiles.d/libvirt.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Cody Istre
+# SPDX-License-Identifier: MIT
+
 d /var/lib/libvirt/boot 0755 root root
 
 d /var/lib/libvirt/dnsmasq 0755 root root

--- a/libvirtd-desktop/files/usr/lib/tmpfiles.d/libvirt.conf
+++ b/libvirtd-desktop/files/usr/lib/tmpfiles.d/libvirt.conf
@@ -1,0 +1,13 @@
+d /var/lib/libvirt/boot 0755 root root
+
+d /var/lib/libvirt/dnsmasq 0755 root root
+
+d /var/lib/libvirt/filesystems 0755 root root
+
+d /var/lib/libvirt/images 0751 root root
+
+d /var/lib/libvirt/network 0700 root root
+
+d /var/lib/libvirt/qemu 0755 qemu qemu
+
+d /var/lib/libvirt/swtpm 0755 root root

--- a/libvirtd-desktop/files/usr/lib/tmpfiles.d/libvirt.conf
+++ b/libvirtd-desktop/files/usr/lib/tmpfiles.d/libvirt.conf
@@ -1,16 +1,7 @@
-# SPDX-FileCopyrightText: 2025 Cody Istre
-# SPDX-License-Identifier: MIT
-
-d /var/lib/libvirt/boot 0755 root root
-
-d /var/lib/libvirt/dnsmasq 0755 root root
-
+d /var/lib/libvirt/boot        0755 root root
+d /var/lib/libvirt/dnsmasq     0755 root root
 d /var/lib/libvirt/filesystems 0755 root root
-
-d /var/lib/libvirt/images 0751 root root
-
-d /var/lib/libvirt/network 0700 root root
-
-d /var/lib/libvirt/qemu 0755 qemu qemu
-
-d /var/lib/libvirt/swtpm 0755 root root
+d /var/lib/libvirt/images      0751 root root
+d /var/lib/libvirt/network     0700 root root
+d /var/lib/libvirt/qemu        0755 qemu qemu
+d /var/lib/libvirt/swtpm       0755 root root


### PR DESCRIPTION
libvirtd-desktop: Move virtlogd override to usr and remove `LogsDirectory` line, remove license headers, align tmpfiles modes