### PR TITLE
github: rm force-rebuild & mv RELEASEURL to composite action

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,10 +11,6 @@ inputs:
     description: "The image to use as a base for the sysext"
     required: true
 
-# This composite action needs the following environment variables to be set at
-# the workflow or job level:
-# - RELEASEURL: Mandatory, needed to fetch older releases
-
 runs:
   using: "composite"
   steps:
@@ -23,6 +19,7 @@ runs:
         SYSEXT: ${{ inputs.sysext }}
         IMAGE: ${{ inputs.image }}
         PR: ${{ github.event_name == 'pull_request' }}
+        RELEASEURL: "https://github.com/${{ github.repository }}/releases/download"
       shell: bash
       run: |
         set -euxo pipefail

--- a/.github/actions/gather/action.yml
+++ b/.github/actions/gather/action.yml
@@ -4,16 +4,13 @@
 name: "Gather versions for sysexts"
 description: "Publish a release that references all available versions for each sysext"
 
-# This composite action needs the following environment variables to be set at
-# the workflow or job level:
-# - RELEASEURL: Mandatory, needed to fetch older releases
-
 runs:
   using: "composite"
   steps:
     - name: "Publish release"
       env:
         GH_TOKEN: ${{ github.token }}
+        RELEASEURL: "https://github.com/${{ github.repository }}/releases/download"
       if: (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
       shell: bash
       run: |

--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -5,7 +5,6 @@ name: "Build sysexts for Fedora"
 
 env:
   GH_TOKEN: ${{ github.token }}
-  RELEASEURL: "https://github.com/${{ github.repository }}/releases/download"
 
 on:
   pull_request:


### PR DESCRIPTION
github/workflows: Remove force-rebuild option

We ended up never using it. If needed, selectively remove the releases
for the sysexts to rebuild and trigger a build.

---

github: Move RELEASEURL env var to composite actions
