### PR TITLE
libvirt*: Add 'python3-virt-firmware' for 'virt-fw-vars'

### DIFF
--- a/libvirtd-desktop/justfile
+++ b/libvirtd-desktop/justfile
@@ -18,6 +18,7 @@ libvirt-dbus
 osinfo-db
 osinfo-db-tools
 netcat
+python3-virt-firmware
 qemu-kvm
 qemu-img
 swtpm

--- a/libvirtd/justfile
+++ b/libvirtd/justfile
@@ -22,6 +22,7 @@ libvirt-daemon-driver-storage-rbd
 libvirt-daemon-driver-storage-scsi
 libvirt-dbus
 netcat
+python3-virt-firmware
 qemu-img
 qemu-kvm
 swtpm


### PR DESCRIPTION
Convenient tool when testing Secure Boot signed images. Used by bcvk.