### PR TITLE
emacs: Explicity request emacs-pgtk (Wayland support)

### DIFF
--- a/emacs/justfile
+++ b/emacs/justfile
@@ -1,7 +1,11 @@
 name := "emacs"
 packages := "
 emacs
+emacs-pgtk
 libvterm
+"
+exclude_packages := "
+emacs-gtk+x11
 "
 dnf_weak_deps := "false"
 


### PR DESCRIPTION
Exclude X11 support (emacs-gtk+x11).

Fixes: https://github.com/fedora-sysexts/fedora/issues/222