### PR TITLE
erofs-utils: Add libdeflate for Fedora CoreOS support

### DIFF
--- a/erofs-utils/justfile
+++ b/erofs-utils/justfile
@@ -1,5 +1,9 @@
 name := "erofs-utils"
-packages := "erofs-utils"
+# libdeflate: Added for Fedora CoreOS support
+packages := "
+erofs-utils
+libdeflate
+"
 
 import '../sysext.just'
 


### PR DESCRIPTION
Fixes: https://github.com/fedora-sysexts/fedora/issues/226