### PR TITLE
libvirt: reload dbus before starting libvirt-dbus

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -30,6 +30,8 @@ path = [
   "libvirtd-desktop/usr/lib/sysusers.d/libvirtdbus-group.conf",
   "libvirtd/usr/lib/systemd/system/virtstoraged.service.d/after-ldreload.conf",
   "libvirtd-desktop/usr/lib/systemd/system/virtstoraged.service.d/after-ldreload.conf",
+  "libvirtd/usr/lib/systemd/system/libvirt-dbus.service.d/reload-dbus.conf",
+  "libvirtd-desktop/usr/lib/systemd/system/libvirt-dbus.service.d/reload-dbus.conf"
 ]
 SPDX-FileCopyrightText = [
     "Fedora sysexts contributors"

--- a/libvirtd-desktop/usr/lib/systemd/system/libvirt-dbus.service.d/reload-dbus.conf
+++ b/libvirtd-desktop/usr/lib/systemd/system/libvirt-dbus.service.d/reload-dbus.conf
@@ -1,0 +1,6 @@
+[Service]
+# We use '+' to run this specific command as root, 
+# even if the rest of the service runs as a restricted user.
+# We do this because the dbus policy file allowing this service to connect
+# to the bus is injected after dbus already started.
+ExecStartPre=+/usr/bin/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig

--- a/libvirtd/usr/lib/systemd/system/libvirt-dbus.service.d/reload-dbus.conf
+++ b/libvirtd/usr/lib/systemd/system/libvirt-dbus.service.d/reload-dbus.conf
@@ -1,0 +1,6 @@
+[Service]
+# We use '+' to run this specific command as root, 
+# even if the rest of the service runs as a restricted user.
+# We do this because the dbus policy file allowing this service to connect
+# to the bus is injected after dbus already started.
+ExecStartPre=+/usr/bin/busctl call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus ReloadConfig


### PR DESCRIPTION
This is necessary because the dbus policy file shipped in the sysext is merged after dbus already started, so we need to reload the policies before starting this service.

This can probably be done in a more generic way by systemd-sysext after the merge I guess.

Tracking issue: https://github.com/systemd/systemd/issues/41662