### PR TITLE
libvirtd: add required upholds for autostart

### DIFF
--- a/libvirtd/README.md
+++ b/libvirtd/README.md
@@ -71,6 +71,8 @@ To add a upholds on `virtqemud`:
 cat <<EOF > /etc/systemd/system/multi-user.target.d/20-qemu-enable-service.conf
 [Unit]
 Upholds=virtqemud.service 
+Upholds=virtlogd.service
+Upholds=virtnetworkd.service
 EOF
 ```
 


### PR DESCRIPTION
Add a couple of missing `Upholds` entries in the documentation to have VMs start on boot.